### PR TITLE
feat(objects): add affect bit selectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -2363,7 +2363,8 @@
                     Vulnerable
                 </option>
             </select>
-            <input class="affect-bits" placeholder="Bits (ej. PV)" type="text" />
+            <select class="affect-bits">
+            </select>
             <button class="remove-sub-btn">
                 X
             </button>

--- a/instrucciones.md
+++ b/instrucciones.md
@@ -126,7 +126,8 @@ La aplicación debe permitir añadir múltiples objetos. Cada objeto tendrá los
 *   **F (Affects permanentes)** (Opcional): Inmunidades, resistencias o vulnerabilidades (ej. `F A 0 0 PV`).
     *   Formato: `F <tipo_affect> <bits_affect>`.
     *   Tipos: `A` (Affected), `I` (Immune), `R` (Resist), `V` (Vulnerable).
-    *   Bits (para Affects/Imm/Res/Vul): `A` (Summon), `B` (Charm), `C` (Magic), `D` (Weapons), `E` (Bash), `F` (Pierce), `G` (Slash), `H` (Fire), `I` (Cold), `J` (Lightning), `K` (Acid), `L` (Poison), `M` (Negative), `N` (Holy), `O` (Energy), `P` (Mental), `Q` (Disease), `R` (Drowning), `S` (Light), `T` (Sound), `X` (Wood), `Y` (Silver), `Z` (Iron).
+    *   Localizaciones para `A` (Affected): `A` (Blind), `B` (Invisible), `C` (Detect_evil), `D` (Detect_invis), `E` (Detect_magic), `F` (Detect_hidden), `G` (Detect_good), `H` (Sanctuary), `I` (Faerie_fire), `J` (Infrared), `K` (Curse), `L` (Flaming - No Implementado), `M` (Poisoned), `N` (Prot_evil), `O` (Prot_good), `P` (Sneak), `Q` (Hide), `R` (Sleep), `S` (Charm), `T` (Flying), `U` (Pass_door), `V` (Haste), `W` (Calm), `X` (Plague), `Y` (Weaken), `Z` (Dark_vis), `a` (Berserk - No Implementado), `b` (Swim - No Implementado), `c` (Regen), `d` (Slow).
+    *   Bits para `I`, `R` y `V`: `A` (Summon), `B` (Charm), `C` (Magic), `D` (Weapons), `E` (Bash), `F` (Pierce), `G` (Slash), `H` (Fire), `I` (Cold), `J` (Lightning), `K` (Acid), `L` (Poison), `M` (Negative), `N` (Holy), `O` (Energy), `P` (Mental), `Q` (Disease), `R` (Drowning), `S` (Light), `T` (Sound), `X` (Wood), `Y` (Silver), `Z` (Iron).
 *   **E (Descripciones adicionales)** (Opcional): (ej. `E inscripcion inscripción~ Esta llave abre...`).
 
 #### **2.4. Sección `#ROOMS`**

--- a/js/config.js
+++ b/js/config.js
@@ -1,3 +1,29 @@
+const affectIRVBits = [
+    { value: 'A', label: 'Summon' },
+    { value: 'B', label: 'Charm' },
+    { value: 'C', label: 'Magic' },
+    { value: 'D', label: 'Weapons' },
+    { value: 'E', label: 'Bash' },
+    { value: 'F', label: 'Pierce' },
+    { value: 'G', label: 'Slash' },
+    { value: 'H', label: 'Fire' },
+    { value: 'I', label: 'Cold' },
+    { value: 'J', label: 'Lightning' },
+    { value: 'K', label: 'Acid' },
+    { value: 'L', label: 'Poison' },
+    { value: 'M', label: 'Negative' },
+    { value: 'N', label: 'Holy' },
+    { value: 'O', label: 'Energy' },
+    { value: 'P', label: 'Mental' },
+    { value: 'Q', label: 'Disease' },
+    { value: 'R', label: 'Drowning' },
+    { value: 'S', label: 'Light' },
+    { value: 'T', label: 'Sound' },
+    { value: 'X', label: 'Wood' },
+    { value: 'Y', label: 'Silver' },
+    { value: 'Z', label: 'Iron' }
+];
+
 export const gameData = {
     // Configuración de las API Keys para los modelos de IA de Gemini.
     // Se pueden añadir múltiples keys para rotación o fallback.
@@ -419,6 +445,44 @@ export const gameData = {
         'furniture': ['gente', 'total wei', 'fur flags', 'heal bon', 'mana bon'],
         'emblema': ['id_clan', 'rango', 'CONFIGURAR A 0', 'CONFIGURAR A 0', 'CONFIGURAR A 0'], // Adjusted for 5 values, empty for unused
         'default': ['Valor 0', 'Valor 1', 'Valor 2', 'Valor 3', 'Valor 4'] // Default for types not explicitly listed
+    },
+
+    affectBitOptions: {
+        A: [
+            { value: 'A', label: 'Blind' },
+            { value: 'B', label: 'Invisible' },
+            { value: 'C', label: 'Detect_evil' },
+            { value: 'D', label: 'Detect_invis' },
+            { value: 'E', label: 'Detect_magic' },
+            { value: 'F', label: 'Detect_hidden' },
+            { value: 'G', label: 'Detect_good' },
+            { value: 'H', label: 'Sanctuary' },
+            { value: 'I', label: 'Faerie_fire' },
+            { value: 'J', label: 'Infrared' },
+            { value: 'K', label: 'Curse' },
+            { value: 'L', label: 'Flaming (No Implementado)' },
+            { value: 'M', label: 'Poisoned' },
+            { value: 'N', label: 'Prot_evil' },
+            { value: 'O', label: 'Prot_good' },
+            { value: 'P', label: 'Sneak' },
+            { value: 'Q', label: 'Hide' },
+            { value: 'R', label: 'Sleep' },
+            { value: 'S', label: 'Charm' },
+            { value: 'T', label: 'Flying' },
+            { value: 'U', label: 'Pass_door' },
+            { value: 'V', label: 'Haste' },
+            { value: 'W', label: 'Calm' },
+            { value: 'X', label: 'Plague' },
+            { value: 'Y', label: 'Weaken' },
+            { value: 'Z', label: 'Dark_vis' },
+            { value: 'a', label: 'Berserk (No Implementado)' },
+            { value: 'b', label: 'Swim (No Implementado)' },
+            { value: 'c', label: 'Regen' },
+            { value: 'd', label: 'Slow' }
+        ],
+        I: affectIRVBits,
+        R: affectIRVBits,
+        V: affectIRVBits
     },
 
     // Prompts detallados para la generación de descripciones de IA.

--- a/js/objects.js
+++ b/js/objects.js
@@ -26,6 +26,20 @@ function populateObjectTypeSelect(objectCard) {
     }
 }
 
+export function populateAffectBitSelect(row) {
+    const type = row.querySelector('.affect-type').value;
+    const select = row.querySelector('.affect-bits');
+    const options = gameData.affectBitOptions[type] || [];
+    select.innerHTML = '';
+    options.forEach(opt => {
+        const option = document.createElement('option');
+        option.value = opt.value;
+        option.textContent = `${opt.value} - ${opt.label}`;
+        select.appendChild(option);
+    });
+    if (options.length > 0) select.selectedIndex = 0;
+}
+
 export function setupObjectsSection(vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector) {
     setupDynamicSection('add-object-btn', 'objects-container', 'object-template', '.object-card', vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector, populateObjectTypeSelect);
 
@@ -34,6 +48,8 @@ export function setupObjectsSection(vnumRangeCheckFunction, vnumSelector, vnumDi
     container.addEventListener('change', e => {
         if (e.target.classList.contains('obj-type')) {
             updateObjectValuesUI(e.target.closest('.object-card'));
+        } else if (e.target.classList.contains('affect-type')) {
+            populateAffectBitSelect(e.target.closest('.sub-item-row'));
         }
     });
 
@@ -41,7 +57,12 @@ export function setupObjectsSection(vnumRangeCheckFunction, vnumSelector, vnumDi
         const target = e.target;
         if (target.classList.contains('remove-btn')) target.closest('.object-card').remove();
         else if (target.classList.contains('add-apply-btn')) target.previousElementSibling.appendChild(document.getElementById('apply-template').content.cloneNode(true));
-        else if (target.classList.contains('add-affect-btn')) target.previousElementSibling.appendChild(document.getElementById('affect-template').content.cloneNode(true));
+        else if (target.classList.contains('add-affect-btn')) {
+            const container = target.previousElementSibling;
+            const fragment = document.getElementById('affect-template').content.cloneNode(true);
+            container.appendChild(fragment);
+            populateAffectBitSelect(container.lastElementChild);
+        }
         else if (target.classList.contains('add-extra-btn')) target.previousElementSibling.appendChild(document.getElementById('extra-desc-template').content.cloneNode(true));
         else if (target.classList.contains('remove-sub-btn')) target.parentElement.remove();
     });

--- a/js/parser.js
+++ b/js/parser.js
@@ -1,3 +1,5 @@
+import { populateAffectBitSelect } from './objects.js';
+
 export function parseAreFile(content) {
     console.log('Parsing .are file...');
 
@@ -295,7 +297,7 @@ function parseObjectsSection(sectionContent) {
                     obj.applies.push({ location: parts[0], modifier: parts[1] });
                 } else if (line.startsWith('F ')) {
                     const parts = line.substring(2).trim().split(' ');
-                    obj.affects.push({ type: parts[0], bits: parts.slice(1).join(' ') });
+                    obj.affects.push({ type: parts[0], bits: parts.slice(3).join('') });
                 } else if (line.startsWith('E ')) {
                     const keywordLine = line.substring(2).trim();
                     const keywordMatch = keywordLine.match(/^(.*?~)\s*(.*)/);
@@ -387,6 +389,7 @@ function populateAffects(containerElement, affectsData) {
         const addedAffectElement = newAffect.querySelector('.sub-item-row');
 
         addedAffectElement.querySelector('.affect-type').value = affect.type;
+        populateAffectBitSelect(addedAffectElement);
         addedAffectElement.querySelector('.affect-bits').value = affect.bits;
 
         affectsContainer.appendChild(addedAffectElement);

--- a/js/sets.js
+++ b/js/sets.js
@@ -1,4 +1,5 @@
 import { setupDynamicSection } from './utils.js';
+import { populateAffectBitSelect } from './objects.js';
 
 export function setupSetSection(vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector) {
     setupDynamicSection('add-set-btn', 'sets-container', 'set-template', '.set-card', vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector);
@@ -13,7 +14,15 @@ export function setupSetSection(vnumRangeCheckFunction, vnumSelector, vnumDispla
         } else if (target.classList.contains('add-apply-btn')) {
             target.previousElementSibling.appendChild(document.getElementById('apply-template').content.cloneNode(true));
         } else if (target.classList.contains('add-affect-btn')) {
-            target.previousElementSibling.appendChild(document.getElementById('affect-template').content.cloneNode(true));
+            const container = target.previousElementSibling;
+            const fragment = document.getElementById('affect-template').content.cloneNode(true);
+            container.appendChild(fragment);
+            populateAffectBitSelect(container.lastElementChild);
+        }
+    });
+    container.addEventListener('change', e => {
+        if (e.target.classList.contains('affect-type')) {
+            populateAffectBitSelect(e.target.closest('.sub-item-row'));
         }
     });
 }

--- a/resumen.md
+++ b/resumen.md
@@ -37,3 +37,7 @@
         *   **Solución**: Se refactorizó la función `getFlagString` en `js/utils.js` para que encuentre el `fieldset` correcto buscando por el texto de su `legend` (`legend.textContent.trim()`).
         *   **Confirmación**: Se verificó mediante `console.log` que `getFlagString` ahora identifica correctamente los `fieldset`s y recolecta los valores de los checkboxes marcados.
         *   **Limpieza**: Se eliminaron los `console.log` de depuración de `js/utils.js` y `js/objects.js`.
+    *   **Affects (F) con Bits Desplegables**:
+        *   **Funcionalidad**: Los Affects ahora utilizan un `<select>` para elegir los bits disponibles en lugar de un campo de texto libre.
+        *   **Opciones Dinámicas**: Las opciones se cargan según el tipo de affect seleccionado (`A`, `I`, `R`, `V`), utilizando la nueva estructura `affectBitOptions` en `js/config.js`.
+        *   **Integración**: La lógica se añadió en `js/objects.js`, `js/sets.js` y `js/parser.js` para poblar y mantener sincronizados estos desplegables.


### PR DESCRIPTION
## Summary
- replace free-form affect bit input with dropdown
- drive options from new `affectBitOptions` config and update objects, sets and parser
- document affect bit types and record progress

## Testing
- `npm test` *(fails: package.json not found)*
- `node --check js/objects.js`
- `node --check js/sets.js`
- `node --check js/parser.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7749f9f7c832d98c73dfa0c09ef02