### PR TITLE
Add configurable object value dropdowns

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -447,6 +447,38 @@ export const gameData = {
         'default': ['Valor 0', 'Valor 1', 'Valor 2', 'Valor 3', 'Valor 4'] // Default for types not explicitly listed
     },
 
+    // Opciones desplegables para los valores V0-V4 según el tipo de objeto.
+    // Si un V específico no está definido para un tipo, se usará "0" por defecto.
+    objectValueOptions: {
+        weapon: {
+            v0: [
+                'espada', 'daga', 'boleadoras', 'maza',
+                'hacha', 'mayal', 'latigo', 'lanza'
+            ],
+            v3: [
+                'slice', 'stab', 'slash', 'latigo', 'claw', 'blast', 'pound',
+                'crush', 'grep', 'bite', 'pierce', 'suction', 'beating',
+                'digestion', 'charge', 'slap', 'punch', 'wrath', 'magic',
+                'divine', 'cleave', 'scratch', 'peck', 'peckb', 'chop',
+                'sting', 'smash', 'shbite', 'flbite', 'frbite', 'acbite',
+                'chomp', 'drain', 'thrust', 'slime', 'shock', 'thwack',
+                'flame', 'chill'
+            ],
+            v4: [
+                { value: 'A', label: 'flaming' },
+                { value: 'B', label: 'frost' },
+                { value: 'C', label: 'vampiric' },
+                { value: 'D', label: 'sharp' },
+                { value: 'E', label: 'vorpal' },
+                { value: 'F', label: 'two-handed' },
+                { value: 'G', label: 'shocking' },
+                { value: 'H', label: 'poisoned' },
+                { value: 'I', label: 'Sangriento' },
+                { value: 'J', label: 'Hemorragia' }
+            ]
+        }
+    },
+
     affectBitOptions: {
         A: [
             { value: 'A', label: 'Blind' },

--- a/js/objects.js
+++ b/js/objects.js
@@ -1,16 +1,66 @@
 import { setupDynamicSection, getFlagString } from './utils.js';
 import { gameData } from './config.js';
 
-function updateObjectValuesUI(objectCard) {
+export function updateObjectValuesUI(objectCard) {
     const type = objectCard.querySelector('.obj-type').value;
     const labels = gameData.objectValueLabels[type] || gameData.objectValueLabels['default'];
+    const optionsConfig = (gameData.objectValueOptions && gameData.objectValueOptions[type]) || {};
+
     for (let i = 0; i < 5; i++) {
         const labelElement = objectCard.querySelector(`label[data-label-for="v${i}"]`);
         if (labelElement) labelElement.textContent = labels[i] + ':';
+
+        const fieldSelector = `.obj-v${i}`;
+        let field = objectCard.querySelector(fieldSelector);
+        const currentValue = field ? field.value : '0';
+        const vOptions = optionsConfig[`v${i}`];
+
+        if (vOptions && vOptions.length > 0) {
+            let select;
+            if (!field || field.tagName.toLowerCase() !== 'select') {
+                select = document.createElement('select');
+                select.className = fieldSelector.slice(1);
+                if (field) field.replaceWith(select);
+                field = select;
+            } else {
+                select = field;
+            }
+
+            select.innerHTML = '';
+            vOptions.forEach((opt, idx) => {
+                const optionEl = document.createElement('option');
+                if (typeof opt === 'object') {
+                    optionEl.value = opt.value;
+                    optionEl.textContent = opt.label;
+                } else {
+                    optionEl.value = opt;
+                    optionEl.textContent = opt;
+                }
+                optionEl.dataset.index = idx;
+                select.appendChild(optionEl);
+            });
+
+            const values = vOptions.map(opt => typeof opt === 'object' ? opt.value : opt);
+            if (values.includes(currentValue)) {
+                select.value = currentValue;
+            } else {
+                select.selectedIndex = 0;
+            }
+        } else {
+            if (!field || field.tagName.toLowerCase() !== 'input') {
+                const input = document.createElement('input');
+                input.type = 'text';
+                input.className = fieldSelector.slice(1);
+                input.value = '0';
+                if (field) field.replaceWith(input);
+                field = input;
+            }
+            if (field.value === '' || field.value === undefined) field.value = '0';
+        }
     }
 }
 
-function populateObjectTypeSelect(objectCard) {
+export function populateObjectTypeSelect(objectCard) {
     const selectElement = objectCard.querySelector('.obj-type');
     if (selectElement) {
         // Clear existing options (if any)

--- a/js/parser.js
+++ b/js/parser.js
@@ -1,4 +1,4 @@
-import { populateAffectBitSelect } from './objects.js';
+import { populateAffectBitSelect, populateObjectTypeSelect, updateObjectValuesUI } from './objects.js';
 
 export function parseAreFile(content) {
     console.log('Parsing .are file...');
@@ -269,12 +269,12 @@ function parseObjectsSection(sectionContent) {
             obj.wearLocation = lines[i++].trim();
 
             // V0-V4
-            const vValues = lines[i++].split(' ').filter(s => s !== '').map(Number);
-            obj.v0 = vValues[0];
-            obj.v1 = vValues[1];
-            obj.v2 = vValues[2];
-            obj.v3 = vValues[3];
-            obj.v4 = vValues[4];
+            const vValues = lines[i++].split(' ').filter(s => s !== '');
+            obj.v0 = vValues[0] ?? '0';
+            obj.v1 = vValues[1] ?? '0';
+            obj.v2 = vValues[2] ?? '0';
+            obj.v3 = vValues[3] ?? '0';
+            obj.v4 = vValues[4] ?? '0';
 
             obj.level = parseInt(lines[i++]);
             obj.weight = parseInt(lines[i++]);
@@ -323,12 +323,15 @@ function populateObjectsSection(objectsData) {
         const newCard = template.content.cloneNode(true);
         const addedCardElement = newCard.querySelector('.object-card');
 
+        populateObjectTypeSelect(addedCardElement);
+        addedCardElement.querySelector('.obj-type').value = obj.type;
+        updateObjectValuesUI(addedCardElement);
+
         addedCardElement.querySelector('.obj-vnum').value = obj.vnum;
         addedCardElement.querySelector('.obj-keywords').value = obj.keywords;
         addedCardElement.querySelector('.obj-short-desc').value = obj.shortDesc;
         addedCardElement.querySelector('.obj-long-desc').value = obj.longDesc;
         addedCardElement.querySelector('.obj-material').value = obj.material;
-        addedCardElement.querySelector('.obj-type').value = obj.type;
         populateCheckboxesFromFlags(addedCardElement, '.obj-flags-checkbox-group', obj.flags);
         addedCardElement.querySelector('.obj-wear-location').value = obj.wearLocation;
 

--- a/resumen.md
+++ b/resumen.md
@@ -24,6 +24,10 @@
         *   **Población Dinámica**: Se modificó `js/objects.js` para importar `gameData` y para que la función `populateObjectTypeSelect` (pasada como `postAddCallback` a `setupDynamicSection`) rellene el `<select>` de "Tipo" con las opciones de `objectTypes`.
         *   **Actualización de Etiquetas**: La función `updateObjectValuesUI` en `js/objects.js` fue modificada para usar `gameData.objectValueLabels` y así cambiar las etiquetas de V0-V4 según el tipo seleccionado.
         *   **Depuración**: Se depuró un problema inicial donde el desplegable de "Tipo" aparecía vacío, lo que llevó a la confirmación de que las listas `objectTypes` y `objectValueLabels` no se habían añadido correctamente en una iteración anterior.
+    *   **Desplegables de V0-V4 por Tipo**:
+        *   **Funcionalidad**: Dependiendo del tipo de objeto, los campos V0-V4 ahora pueden mostrarse como `<select>` con opciones predefinidas.
+        *   **Configuración**: Se añadió la estructura `objectValueOptions` a `gameData` en `js/config.js`, permitiendo definir listas como tipos de armas, daños o flags para cada V.
+        *   **Integración**: `js/objects.js` actualiza dinámicamente estos campos y `js/parser.js` fue adaptado para soportar los nuevos desplegables.
     *   **Eliminación de Campos Redundantes**:
         *   **V0-V4**: Se eliminó un grupo redundante de campos de entrada V0-V4 (`<input type="number">`) del `object-template` en `index.html`, asegurando que solo el `fieldset` con las etiquetas dinámicas sea el utilizado.
         *   **Flags y Lugar de Vestir**: Se eliminaron los campos de entrada de texto redundantes para "Flags" y "Lugar de vestir" del `object-template` en `index.html`, manteniendo solo los `fieldset`s con checkboxes.


### PR DESCRIPTION
## Summary
- Allow V0-V4 fields to display selectable lists based on object type
- Add `objectValueOptions` in config to store per-type V field options
- Adjust parser and UI logic to support new dropdown configuration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b85f4eb00c832d80ad6cac1d0c5e7f