### PR TITLE
Corrige escritura de flags de habitación en archivo .are

### DIFF
--- a/js/rooms.js
+++ b/js/rooms.js
@@ -23,7 +23,7 @@ export function generateRoomsSection() {
         section += `${room.querySelector('.room-name').value}~\n`;
         section += `${room.querySelector('.room-desc').value.replace(/\n/g, ' ')}~\n`;
 
-        const roomFlags = getFlagString(room, 'fieldset[legend="Flags de Habitación"] input[type="checkbox"]');
+        const roomFlags = getFlagString(room, 'Flags de Habitación');
         section += `0 ${roomFlags} ${room.querySelector('.room-sector').value}\n`;
 
         room.querySelectorAll('.exits-container .sub-item-row-grid').forEach(row => {

--- a/resumen.md
+++ b/resumen.md
@@ -48,3 +48,5 @@
         *   **Funcionalidad**: Los Affects ahora utilizan un `<select>` para elegir los bits disponibles en lugar de un campo de texto libre.
         *   **Opciones Dinámicas**: Las opciones se cargan según el tipo de affect seleccionado (`A`, `I`, `R`, `V`), utilizando la nueva estructura `affectBitOptions` en `js/config.js`.
         *   **Integración**: La lógica se añadió en `js/objects.js`, `js/sets.js` y `js/parser.js` para poblar y mantener sincronizados estos desplegables.
+*   **Mejoras en la Sección Rooms**:
+    *   **Flags de Habitación**: Se corrigió la llamada a `getFlagString` en `js/rooms.js`, permitiendo que los flags seleccionados se escriban correctamente en el archivo `.are`.


### PR DESCRIPTION
## Resumen
- Corrige la generación de flags de habitación al usar `getFlagString` con la nueva firma.
- Documenta la corrección en `resumen.md`.

## Testing
- `npm test` *(falla: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b9a4c65134832da649dd32bb61c958