### PR TITLE
Add room-specific extra description prompt

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1268,7 +1268,8 @@ export const gameData = {
             extra: "Basado en la siguiente idea: ${promptText}, genera UN ÚNICO objeto JSON con una descripción extra para un objeto de un juego MUD. Esta descripción debe ser extensa y muy descriptiva, similar a la descripción al mirar de un mob, detallando el objeto, su apariencia, historia, etc. Responde solo con el objeto JSON, usando la clave \"extra_desc\"."
         },
         room: {
-            description: "Basado en la siguiente idea: ${promptText}, genera UN ÚNICO objeto JSON con una descripción para una habitación de un juego MUD. Esta descripción debe ser extensa y muy descriptiva, detallando el ambiente, objetos, sonidos, olores, etc. Responde solo con el objeto JSON, usando la clave \"room_desc\"."
+            description: "Basado en la siguiente idea: ${promptText}, genera UN ÚNICO objeto JSON con una descripción para una habitación de un juego MUD. Esta descripción debe ser extensa y muy descriptiva, detallando el ambiente, objetos, sonidos, olores, etc. Responde solo con el objeto JSON, usando la clave \"room_desc\".",
+            extra: "Basado en la siguiente idea: ${promptText}, genera UN ÚNICO objeto JSON con una descripción extra para una habitación de un juego MUD. Esta descripción debe ser muy descriptiva sin ser extremadamente larga, detallando el ambiente, su historia u otros elementos relevantes. Responde solo con el objeto JSON, usando la clave \"extra_desc\"."
         }
     }
     // Aquí se pueden añadir futuras listas (materiales, tipos de armas, etc.)

--- a/js/utils.js
+++ b/js/utils.js
@@ -175,16 +175,23 @@ async function handleObjectShortLongAiGeneration(e) {
     await generateDescriptions(generateBtn, promptText, promptInstructions, targetFields);
 }
 
-// Object Extra Description AI generation handler
+// Extra Description AI generation handler for objects and rooms
 async function handleExtraDescAiGeneration(e) {
     const generateBtn = e.target;
-    const card = generateBtn.closest('.sub-item-row'); // Note: closest sub-item-row
+    const card = generateBtn.closest('.sub-item-row');
     if (!card) return;
 
     const promptText = card.querySelector('.ai-prompt').value;
-    const extraDescInput = card.querySelector('.extra-desc'); // Note: extra-desc
+    const extraDescInput = card.querySelector('.extra-desc');
 
-    const promptInstructions = gameData.aiPrompts.object.extra;;
+    let promptInstructions;
+    if (generateBtn.closest('.object-card')) {
+        promptInstructions = gameData.aiPrompts.object.extra;
+    } else if (generateBtn.closest('.room-card')) {
+        promptInstructions = gameData.aiPrompts.room.extra;
+    } else {
+        promptInstructions = gameData.aiPrompts.object.extra;
+    }
 
     const targetFields = {
         extra_desc: extraDescInput

--- a/resumen.md
+++ b/resumen.md
@@ -50,3 +50,4 @@
         *   **Integración**: La lógica se añadió en `js/objects.js`, `js/sets.js` y `js/parser.js` para poblar y mantener sincronizados estos desplegables.
 *   **Mejoras en la Sección Rooms**:
     *   **Flags de Habitación**: Se corrigió la llamada a `getFlagString` en `js/rooms.js`, permitiendo que los flags seleccionados se escriban correctamente en el archivo `.are`.
+    *   **Descripciones Adicionales con IA**: Se agregó un prompt específico para habitaciones y la lógica necesaria para que las descripciones extra utilicen instrucciones diferentes según si pertenecen a un objeto o a una habitación.


### PR DESCRIPTION
## Summary
- add dedicated AI prompt for room extra descriptions
- adjust extra description handler to use object or room prompts as appropriate
- document the change in resumen.md

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9e3f6978832d803677fe9201ade7