### PR TITLE
Mejoré la creación de reseteos

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,26 +178,26 @@
                     <span>
                         Añadir comando:
                     </span>
-                    <button class="add-reset-btn" data-type="M">
-                        M
+                    <button class="add-reset-btn" data-type="M" title="Carga mobs en habitaciones">
+                        M Mob
                     </button>
-                    <button class="add-reset-btn" data-type="O">
-                        O
+                    <button class="add-reset-btn" data-type="O" title="Carga objetos en habitaciones">
+                        O Objeto
                     </button>
-                    <button class="add-reset-btn" data-type="P">
-                        P
+                    <button class="add-reset-btn" data-type="P" title="Coloca objetos dentro de otros">
+                        P Dentro
                     </button>
-                    <button class="add-reset-btn" data-type="G">
-                        G
+                    <button class="add-reset-btn" data-type="G" title="Da un objeto al último mob">
+                        G Dar
                     </button>
-                    <button class="add-reset-btn" data-type="E">
-                        E
+                    <button class="add-reset-btn" data-type="E" title="Equipa un objeto al último mob">
+                        E Equipar
                     </button>
-                    <button class="add-reset-btn" data-type="D">
-                        D
+                    <button class="add-reset-btn" data-type="D" title="Configura el estado de una puerta">
+                        D Puerta
                     </button>
-                    <button class="add-reset-btn" data-type="R">
-                        R
+                    <button class="add-reset-btn" data-type="R" title="Define un maze en una habitación">
+                        R Maze
                     </button>
                 </div>
                 <div id="resets-list-container">
@@ -2410,7 +2410,7 @@
             <label>
                 Mob Vnum:
             </label>
-            <input class="reset-mob-vnum" type="number" />
+            <select class="reset-mob-vnum"></select>
             <label>
                 Límite Total:
             </label>
@@ -2418,7 +2418,7 @@
             <label>
                 Habitación Vnum:
             </label>
-            <input class="reset-room-vnum" type="number" />
+            <select class="reset-room-vnum"></select>
             <label>
                 Límite Local:
             </label>
@@ -2430,7 +2430,7 @@
             <label>
                 Objeto Vnum:
             </label>
-            <input class="reset-obj-vnum" type="number" />
+            <select class="reset-obj-vnum"></select>
             <label>
                 Límite:
             </label>
@@ -2438,7 +2438,7 @@
             <label>
                 Habitación Vnum:
             </label>
-            <input class="reset-room-vnum" type="number" />
+            <select class="reset-room-vnum"></select>
         </div>
     </template>
     <template id="reset-p-template">
@@ -2446,7 +2446,7 @@
             <label>
                 Contenido Vnum:
             </label>
-            <input class="reset-content-vnum" type="number" />
+            <select class="reset-content-vnum"></select>
             <label>
                 Límite:
             </label>
@@ -2454,7 +2454,7 @@
             <label>
                 Contenedor Vnum:
             </label>
-            <input class="reset-container-vnum" type="number" />
+            <select class="reset-container-vnum"></select>
             <label>
                 Límite Local:
             </label>
@@ -2466,7 +2466,7 @@
             <label>
                 Objeto Vnum:
             </label>
-            <input class="reset-obj-vnum" type="number" />
+            <select class="reset-obj-vnum"></select>
             <label>
                 Límite:
             </label>
@@ -2478,7 +2478,7 @@
             <label>
                 Objeto Vnum:
             </label>
-            <input class="reset-obj-vnum" type="number" />
+            <select class="reset-obj-vnum"></select>
             <label>
                 Límite:
             </label>
@@ -2486,7 +2486,7 @@
             <label>
                 Lugar de Vestir:
             </label>
-            <input class="reset-wear-location" type="number" />
+            <select class="reset-wear-location"></select>
         </div>
     </template>
     <template id="reset-d-template">
@@ -2494,15 +2494,15 @@
             <label>
                 Habitación Vnum:
             </label>
-            <input class="reset-room-vnum" type="number" />
+            <select class="reset-room-vnum"></select>
             <label>
                 Dirección:
             </label>
-            <input class="reset-direction" type="number" />
+            <select class="reset-direction"></select>
             <label>
                 Estado:
             </label>
-            <input class="reset-state" type="number" />
+            <select class="reset-state"></select>
         </div>
     </template>
     <template id="reset-r-template">
@@ -2510,11 +2510,11 @@
             <label>
                 Habitación Vnum:
             </label>
-            <input class="reset-room-vnum" type="number" />
+            <select class="reset-room-vnum"></select>
             <label>
                 Clase de Maze:
             </label>
-            <input class="reset-maze-class" type="number" />
+            <select class="reset-maze-class"></select>
         </div>
     </template>
     <template id="tier-template">

--- a/instrucciones.md
+++ b/instrucciones.md
@@ -278,6 +278,9 @@ La aplicación actual proporciona las siguientes características para facilitar
 *   **Interfaz de Usuario Detallada por Sección**:
     *   Cada sección presenta formularios específicos con campos de entrada para todas las propiedades relevantes de Mobs, Objetos, Habitaciones, Resets, Sets, Tiendas, Especiales y Progs, según la estructura del archivo `.are`.
     *   Se incluyen campos para flags, tipos, materiales, y valores especiales, con opciones de selección donde aplica.
+*   **Selección Guiada en Resets**: La sección de reseteos permite escoger mobs, objetos y habitaciones existentes mediante menús desplegables que se actualizan de forma automática para evitar errores de VNUM.
+*   **Botones de Reseteo Etiquetados**: Los comandos M, O, P, G, E, D y R muestran su significado y ofrecen ayuda emergente para aclarar su uso.
+*   **Listas Predefinidas en Resets**: Dirección, estado de puerta, lugar de vestir y clase de maze se seleccionan desde desplegables alimentados por `js/config.js`.
 *   **Generación de Archivo .are**: Un botón "Generar Archivo .are" compila toda la información introducida en el formato de texto exacto requerido por el MUD "Petria" y permite la descarga del archivo resultante.
 *   **Mejora de Navegación y Edición (Colapsar/Expandir Secciones)**: Se ha implementado la funcionalidad de colapsar/expandir para cada tarjeta individual de elemento (Mob, Objeto, Habitación, Prog, Set, Tienda, Especial). Esto permite ocultar los detalles de las tarjetas no activas, mejorando la visibilidad y reduciendo el desplazamiento vertical. Las nuevas tarjetas se muestran expandidas por defecto.
 

--- a/js/config.js
+++ b/js/config.js
@@ -1257,6 +1257,54 @@ export const gameData = {
         V: affectIRVBits
     },
 
+    resetDirections: [
+        { value: '0', label: 'Norte' },
+        { value: '1', label: 'Este' },
+        { value: '2', label: 'Sur' },
+        { value: '3', label: 'Oeste' },
+        { value: '4', label: 'Arriba' },
+        { value: '5', label: 'Abajo' }
+    ],
+
+    resetDoorStates: [
+        { value: '0', label: 'Abierta' },
+        { value: '1', label: 'Cerrada' },
+        { value: '2', label: 'Con llave' }
+    ],
+
+    resetWearLocations: [
+        { value: '-1', label: 'No vestir' },
+        { value: '0', label: 'Luz' },
+        { value: '1', label: 'Dedo izquierdo' },
+        { value: '2', label: 'Dedo derecho' },
+        { value: '3', label: 'Cuello (1)' },
+        { value: '4', label: 'Cuello (2)' },
+        { value: '5', label: 'En el torso' },
+        { value: '6', label: 'Cabeza' },
+        { value: '7', label: 'Piernas' },
+        { value: '8', label: 'Pies' },
+        { value: '9', label: 'Manos' },
+        { value: '10', label: 'Brazos' },
+        { value: '11', label: 'Escudo' },
+        { value: '12', label: 'En la espalda' },
+        { value: '13', label: 'Cintura' },
+        { value: '14', label: 'Muñeca izquierda' },
+        { value: '15', label: 'Muñeca derecha' },
+        { value: '16', label: 'Blandido' },
+        { value: '17', label: 'Sujeto' },
+        { value: '18', label: 'Flotando' },
+        { value: '19', label: 'Arma secundaria' },
+        { value: '20', label: 'Rodela' },
+        { value: '21', label: 'Piernas traseras (centauro)' },
+        { value: '22', label: 'Pies traseros (centauro)' },
+        { value: '23', label: 'Emblema de clan' }
+    ],
+
+    resetMazeClasses: [
+        { value: '4', label: 'Cardinales' },
+        { value: '6', label: 'Cardinales + arriba/abajo' }
+    ],
+
     // Prompts detallados para la generación de descripciones de IA.
     // Cada clave representa un tipo de entidad (mob, object, room) y contiene sub-prompts específicos.
     aiPrompts: {

--- a/js/mobiles.js
+++ b/js/mobiles.js
@@ -1,5 +1,6 @@
 import { setupDynamicSection, getFlagString } from './utils.js';
 import { gameData } from './config.js';
+import { refrescarOpcionesResets } from './resets.js';
 
 export function setupMobilesSection(vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector) {
     const mobContainer = document.getElementById('mobiles-container');
@@ -123,7 +124,10 @@ export function setupMobilesSection(vnumRangeCheckFunction, vnumSelector, vnumDi
     };
 
     // Call setupDynamicSection and pass the callback for new cards
-    setupDynamicSection('add-mob-btn', 'mobiles-container', 'mob-template', '.mob-card', vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector, attachMobCardListeners);
+    setupDynamicSection('add-mob-btn', 'mobiles-container', 'mob-template', '.mob-card', vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector, (cardElement) => {
+        attachMobCardListeners(cardElement);
+        refrescarOpcionesResets();
+    });
 
     // Attach event listeners for existing cards if they are loaded (e.g., from file)
     mobContainer.querySelectorAll('.mob-card').forEach(card => {

--- a/js/objects.js
+++ b/js/objects.js
@@ -1,5 +1,6 @@
 import { setupDynamicSection, getFlagString } from './utils.js';
 import { gameData } from './config.js';
+import { refrescarOpcionesResets } from './resets.js';
 
 export function updateObjectValuesUI(objectCard) {
     const type = objectCard.querySelector('.obj-type').value;
@@ -103,7 +104,10 @@ export function populateAffectBitSelect(row) {
 }
 
 export function setupObjectsSection(vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector) {
-    setupDynamicSection('add-object-btn', 'objects-container', 'object-template', '.object-card', vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector, populateObjectTypeSelect);
+    setupDynamicSection('add-object-btn', 'objects-container', 'object-template', '.object-card', vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector, (card) => {
+        populateObjectTypeSelect(card);
+        refrescarOpcionesResets();
+    });
 
     // Add event listener for type change on newly added cards
     const container = document.getElementById('objects-container');

--- a/js/parser.js
+++ b/js/parser.js
@@ -1,4 +1,5 @@
 import { populateAffectBitSelect, populateObjectTypeSelect, updateObjectValuesUI } from './objects.js';
+import { refrescarOpcionesResets } from './resets.js';
 
 export function parseAreFile(content) {
     console.log('Parsing .are file...');
@@ -62,6 +63,8 @@ export function parseAreFile(content) {
         parsedData.resets = parseResetsSection(sections['#RESETS']);
         populateResetsSection(parsedData.resets);
     }
+
+    refrescarOpcionesResets();
 
     if (sections['#SET']) {
         parsedData.sets = parseSetSection(sections['#SET']);

--- a/js/rooms.js
+++ b/js/rooms.js
@@ -1,7 +1,10 @@
 import { setupDynamicSection, getFlagString } from './utils.js';
+import { refrescarOpcionesResets } from './resets.js';
 
 export function setupRoomsSection(vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector) {
-    setupDynamicSection('add-room-btn', 'rooms-container', 'room-template', '.room-card', vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector);
+    setupDynamicSection('add-room-btn', 'rooms-container', 'room-template', '.room-card', vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector, () => {
+        refrescarOpcionesResets();
+    });
 
     const container = document.getElementById('rooms-container');
     container.addEventListener('click', (e) => {

--- a/resumen.md
+++ b/resumen.md
@@ -52,3 +52,8 @@
 *   **Mejoras en la Sección Rooms**:
     *   **Flags de Habitación**: Se corrigió la llamada a `getFlagString` en `js/rooms.js`, permitiendo que los flags seleccionados se escriban correctamente en el archivo `.are`.
     *   **Descripciones Adicionales con IA**: Se agregó un prompt específico para habitaciones y la lógica necesaria para que las descripciones extra utilicen instrucciones diferentes según si pertenecen a un objeto o a una habitación.
+*   **Mejoras en la Sección Resets**:
+    *   **Selección Desplegable de VNUMs**: Los campos para mobs, objetos y habitaciones fueron reemplazados por menús desplegables que muestran las entidades ya creadas, reduciendo errores al escribir VNUMs manualmente.
+    *   **Actualización Automática de Opciones**: Al añadir o eliminar mobs, objetos o habitaciones, las opciones de los reseteos se refrescan automáticamente para reflejar los cambios.
+    *   **Comandos Claros**: Los botones M, O, P, G, E, D y R muestran su significado y un `tooltip` explicativo.
+    *   **Parámetros Seleccionables**: Dirección, estado de puerta, lugar de vestir y clase de maze ahora se eligen desde listas definidas en `js/config.js`.

--- a/script.js
+++ b/script.js
@@ -2,7 +2,7 @@ import { setupAreaSection, generateAreaSection } from './js/area.js';
 import { setupMobilesSection, generateMobilesSection } from './js/mobiles.js';
 import { setupObjectsSection, generateObjectsSection } from './js/objects.js';
 import { setupRoomsSection, generateRoomsSection } from './js/rooms.js';
-import { setupResetsSection, generateResetsSection } from './js/resets.js';
+import { setupResetsSection, generateResetsSection, refrescarOpcionesResets } from './js/resets.js';
 import { setupSetSection, generateSetSection } from './js/sets.js';
 import { setupShopsSection, generateShopsSection } from './js/shops.js';
 import { setupSpecialsSection, generateSpecialsSection } from './js/specials.js';
@@ -41,6 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
     setupMobilesSection(isValidVnumRange, '.mob-vnum', '.mob-vnum-display', '.mob-keywords', '.mob-name-display');
     setupRoomsSection(isValidVnumRange, '.room-vnum', '.room-vnum-display', '.room-name', '.room-name-display');
     setupResetsSection();
+    refrescarOpcionesResets();
     setupSetSection(null, '.set-id', '.set-id-display', '.set-name', '.set-name-display');
     setupShopsSection(isValidVnumRange, '.shop-vnum', '.shop-vnum-display', null, null);
     setupSpecialsSection(isValidVnumRange, '.special-vnum', '.special-vnum-display', '.special-comment', '.special-name-display');


### PR DESCRIPTION
## Resumen
- Etiqueté los comandos M/O/P/G/E/D/R con su significado y un `tooltip` aclaratorio.
- Convertí dirección, estado de puerta, lugar de vestir y clase de maze en desplegables alimentados desde `js/config.js`.
- Actualicé `instrucciones.md` y `resumen.md` con la guía de comandos y las nuevas listas configurables.

## Pruebas
- `npm test` *(falla: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68baa97ccf54832dba132fd7ab277125