### PR TITLE
Editor de PROGs en ventana modal con bloques coloreados

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,8 +282,8 @@
             </section>
         </main>
     </div>
-    <script src="script.js" type="module">
-    </script>
+    <script src="https://unpkg.com/blockly/blockly.min.js"></script>
+    <script src="script.js" type="module"></script>
     <!-- ALL TEMPLATES -->
     <template id="mob-template">
         <div class="mob-card">
@@ -2204,10 +2204,12 @@
                     <input class="prog-vnum" placeholder="12100" type="number" />
                 </div>
                 <div class="form-group full-width">
-                    <label>
-                        Código:
-                    </label>
-                    <textarea class="prog-code" placeholder="if rand 50..." rows="10"></textarea>
+                    <div class="prog-summary">(sin acciones)</div>
+                    <button class="edit-prog-btn">Editar bloques</button>
+                    <button class="show-code-btn">Ver código</button>
+                    <pre class="prog-code-display" hidden></pre>
+                    <textarea class="prog-code" hidden></textarea>
+                    <textarea class="prog-xml" hidden></textarea>
                 </div>
             </div>
         </div>
@@ -2573,6 +2575,15 @@
             </fieldset>
         </div>
     </template>
+    <div id="blockly-modal" hidden>
+        <div class="modal-contenido">
+            <div id="blockly-workspace"></div>
+            <div class="modal-controles">
+                <button id="blockly-save">Guardar</button>
+                <button id="blockly-close">Cerrar</button>
+            </div>
+        </div>
+    </div>
     <datalist id="materials-list">
     </datalist>
     <datalist id="specials-list">

--- a/instrucciones.md
+++ b/instrucciones.md
@@ -213,7 +213,7 @@ La aplicación debe permitir definir múltiples especiales. Cada especial tendr�
 La aplicación debe permitir definir múltiples programas. Cada programa tendrá:
 
 *   **Vnum**: Número identificador único (ej. `12100`).
-*   **Bloque de código**: Un editor de texto para el código del programa.
+*   **Bloque de código**: Un editor visual basado en Blockly que se abre en una ventana modal de pantalla completa, genera el código del programa y lo almacena en un `<textarea>` oculto mostrando además un resumen en la tarjeta.
     *   **Sintaxis de Control de Flujo**: `if {if_check} {argument} {operator} {value} [or/and ...] else endif`.
     *   **Comandos MUD y de control de flujo**: `mob echo`, `mob oload`, `mob junk`, `mob force`, `mob damage`, `mob kill`, `mob remove`, `break`, `sleep` (¡sin `mob`!).
     *   **Variables**: `$i, $I, $n, $d, $N, $t, $T, $r, $R, $w, $q, $Q, $j, $e, $E, $J, $k, $m, $M, $K, $l, $s, $S, $L, $o, $O, $p, $P, $a, $b, $c, $A, $B, $C, $u, $v`.

--- a/js/blockly-progs.js
+++ b/js/blockly-progs.js
@@ -1,0 +1,638 @@
+import { gameData } from './config.js';
+
+const COLORES = {
+    eventos: '#5C81A6',
+    condiciones: '#5CA65C',
+    acciones: '#A65C81',
+    logica: '#9A5CA6',
+    variables: '#A6745C'
+};
+
+let espacioTrabajo = null;
+let areaCodigoActual = null;
+let areaXmlActual = null;
+let resumenActual = null;
+let preCodigoActual = null;
+
+/*
+ * El editor se abre en una ventana modal para disponer de todo el espacio.
+ * Se guarda tanto el código generado como el XML del espacio de trabajo para
+ * permitir futuras ediciones.
+ */
+
+function opcionesVariables() {
+    return gameData.progVariables.map(v => [v.label, v.value]);
+}
+
+function crearToolbox() {
+    const bloquesVariables = gameData.progVariables
+        .map(v => `<block type="var_${v.value.replace('$', '')}"></block>`)
+        .join('');
+    return `<xml xmlns="https://developers.google.com/blockly/xml">
+  <category name="Eventos" colour="${COLORES.eventos}">
+    <block type="event_speech"></block>
+    <block type="event_act"></block>
+    <block type="event_random"></block>
+    <block type="event_greet"></block>
+    <block type="event_give"></block>
+  </category>
+  <category name="Condiciones" colour="${COLORES.condiciones}">
+    <block type="cond_ispc"></block>
+    <block type="cond_level"></block>
+    <block type="cond_alineacion"></block>
+    <block type="cond_carries"></block>
+    <block type="cond_pquestactiva"></block>
+    <block type="cond_pquestfase"></block>
+    <block type="cond_pquestfin"></block>
+  </category>
+  <category name="Acciones" colour="${COLORES.acciones}">
+    <block type="action_echo"></block>
+    <block type="action_echoat"></block>
+    <block type="action_mload"></block>
+    <block type="action_oload"></block>
+    <block type="action_transfer"></block>
+    <block type="action_force"></block>
+    <block type="action_pquestinicio"></block>
+    <block type="action_pquestfase"></block>
+    <block type="action_pquestfin"></block>
+    <block type="action_sleep"></block>
+    <block type="action_break"></block>
+  </category>
+  <category name="Lógica" colour="${COLORES.logica}">
+    <block type="mprog_if"></block>
+  </category>
+  <category name="Variables" colour="${COLORES.variables}">
+    ${bloquesVariables}
+  </category>
+</xml>`;
+}
+
+function abrirModal(tipoSeccion, areaCodigo, areaXml, resumen, preCodigo) {
+    const modal = document.getElementById('blockly-modal');
+    modal.removeAttribute('hidden');
+
+    areaCodigoActual = areaCodigo;
+    areaXmlActual = areaXml;
+    resumenActual = resumen;
+    preCodigoActual = preCodigo;
+
+    if (!espacioTrabajo) {
+        espacioTrabajo = Blockly.inject('blockly-workspace', { toolbox: crearToolbox() });
+    }
+
+    espacioTrabajo.programType = tipoSeccion === 'mobprogs' ? 'mob' : tipoSeccion === 'objprogs' ? 'obj' : 'room';
+    espacioTrabajo.clear();
+    if (areaXml.value) {
+        const dom = Blockly.Xml.textToDom(areaXml.value);
+        Blockly.Xml.domToWorkspace(dom, espacioTrabajo);
+    }
+}
+
+function cerrarModal() {
+    document.getElementById('blockly-modal').setAttribute('hidden', true);
+}
+
+function guardarModal() {
+    if (!espacioTrabajo) return;
+    const codigo = Blockly.JavaScript.workspaceToCode(espacioTrabajo).trim();
+    areaCodigoActual.value = codigo;
+    const dom = Blockly.Xml.workspaceToDom(espacioTrabajo);
+    areaXmlActual.value = Blockly.Xml.domToText(dom);
+    resumenActual.textContent = codigo ? codigo.split('\n')[0] : '(sin acciones)';
+    if (!preCodigoActual.hasAttribute('hidden')) {
+        preCodigoActual.textContent = codigo;
+    }
+    cerrarModal();
+}
+
+document.getElementById('blockly-close').addEventListener('click', cerrarModal);
+document.getElementById('blockly-save').addEventListener('click', guardarModal);
+
+export function initProgBlockly(tarjeta, tipoSeccion) {
+    const btnEditar = tarjeta.querySelector('.edit-prog-btn');
+    const btnCodigo = tarjeta.querySelector('.show-code-btn');
+    const areaCodigo = tarjeta.querySelector('.prog-code');
+    const areaXml = tarjeta.querySelector('.prog-xml');
+    const resumen = tarjeta.querySelector('.prog-summary');
+    const preCodigo = tarjeta.querySelector('.prog-code-display');
+
+    btnEditar.addEventListener('click', () => abrirModal(tipoSeccion, areaCodigo, areaXml, resumen, preCodigo));
+
+    btnCodigo.addEventListener('click', () => {
+        preCodigo.textContent = areaCodigo.value;
+        preCodigo.toggleAttribute('hidden');
+    });
+
+    resumen.textContent = areaCodigo.value ? areaCodigo.value.split('\n')[0] : '(sin acciones)';
+}
+
+// Bloques de Eventos
+Blockly.Blocks['event_speech'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('Cuando un jugador diga')
+            .appendField(new Blockly.FieldTextInput('hola'), 'TEXTO');
+        this.appendStatementInput('CUERPO').setCheck(null).appendField('hacer');
+        this.setColour(COLORES.eventos);
+        this.setTooltip('Se activa cuando un jugador dice la palabra o frase especificada en la misma habitación.');
+        this.setHat('cap');
+    }
+};
+
+Blockly.JavaScript['event_speech'] = function (block) {
+    const texto = block.getFieldValue('TEXTO');
+    const cuerpo = Blockly.JavaScript.statementToCode(block, 'CUERPO');
+    return `speech ${texto}\n${cuerpo}`;
+};
+
+Blockly.Blocks['event_act'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('Cuando ocurra una acción que contenga')
+            .appendField(new Blockly.FieldTextInput('texto'), 'TEXTO');
+        this.appendStatementInput('CUERPO').setCheck(null).appendField('hacer');
+        this.setColour(COLORES.eventos);
+        this.setTooltip('Se activa cuando en la habitación ocurre una acción que contiene el texto indicado.');
+        this.setHat('cap');
+    }
+};
+
+Blockly.JavaScript['event_act'] = function (block) {
+    const texto = block.getFieldValue('TEXTO');
+    const cuerpo = Blockly.JavaScript.statementToCode(block, 'CUERPO');
+    return `act ${texto}\n${cuerpo}`;
+};
+
+Blockly.Blocks['event_random'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('De forma aleatoria (probabilidad % )')
+            .appendField(new Blockly.FieldNumber(50, 0, 100), 'NUM');
+        this.appendStatementInput('CUERPO').setCheck(null).appendField('hacer');
+        this.setColour(COLORES.eventos);
+        this.setTooltip('Se activa al azar según el porcentaje indicado.');
+        this.setHat('cap');
+    }
+};
+
+Blockly.JavaScript['event_random'] = function (block) {
+    const num = block.getFieldValue('NUM');
+    const cuerpo = Blockly.JavaScript.statementToCode(block, 'CUERPO');
+    return `random ${num}\n${cuerpo}`;
+};
+
+Blockly.Blocks['event_greet'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('Cuando alguien entre en la habitación')
+            .appendField(new Blockly.FieldDropdown([
+                ['si el personaje es visible', 'greet'],
+                ['siempre', 'grall']
+            ]), 'TIPO')
+            .appendField('con probabilidad %')
+            .appendField(new Blockly.FieldNumber(100, 0, 100), 'NUM');
+        this.appendStatementInput('CUERPO').setCheck(null).appendField('hacer');
+        this.setColour(COLORES.eventos);
+        this.setTooltip('Se activa cuando cualquier personaje entra en la habitación.');
+        this.setHat('cap');
+    }
+};
+
+Blockly.JavaScript['event_greet'] = function (block) {
+    const tipo = block.getFieldValue('TIPO');
+    const num = block.getFieldValue('NUM');
+    const cuerpo = Blockly.JavaScript.statementToCode(block, 'CUERPO');
+    return `${tipo} ${num}\n${cuerpo}`;
+};
+
+Blockly.Blocks['event_give'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('Cuando se le entregue el objeto')
+            .appendField(new Blockly.FieldTextInput('objeto'), 'OBJ');
+        this.appendStatementInput('CUERPO').setCheck(null).appendField('hacer');
+        this.setColour(COLORES.eventos);
+        this.setTooltip('Se activa cuando un jugador da un objeto específico.');
+        this.setHat('cap');
+    }
+};
+
+Blockly.JavaScript['event_give'] = function (block) {
+    const obj = block.getFieldValue('OBJ');
+    const cuerpo = Blockly.JavaScript.statementToCode(block, 'CUERPO');
+    return `give ${obj}\n${cuerpo}`;
+};
+
+// Bloque IF
+Blockly.Blocks['mprog_if'] = {
+    init: function () {
+        this.appendValueInput('COND').setCheck('Boolean').appendField('Si');
+        this.appendStatementInput('ENTONCES').setCheck(null).appendField('hacer');
+        this.appendStatementInput('SINO').setCheck(null).appendField('si no');
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+        this.setColour(COLORES.logica);
+        this.setTooltip('Si... hacer... si no...');
+    }
+};
+
+Blockly.JavaScript['mprog_if'] = function (block) {
+    const cond = Blockly.JavaScript.valueToCode(block, 'COND', Blockly.JavaScript.ORDER_NONE) || '';
+    const entonces = Blockly.JavaScript.statementToCode(block, 'ENTONCES');
+    const sino = Blockly.JavaScript.statementToCode(block, 'SINO');
+    let code = `if ${cond.trim()}\n${entonces}`;
+    if (sino.trim()) {
+        code += `else\n${sino}`;
+    }
+    code += 'endif\n';
+    return code;
+};
+
+// Bloques de Condición
+Blockly.Blocks['cond_ispc'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField(new Blockly.FieldDropdown(opcionesVariables()), 'VAR')
+            .appendField('es')
+            .appendField(new Blockly.FieldDropdown([
+                ['un jugador', 'ispc'],
+                ['un NPC', 'isnpc']
+            ]), 'TIPO');
+        this.setOutput(true, 'Boolean');
+        this.setColour(COLORES.condiciones);
+        this.setTooltip('Comprueba si el objetivo es jugador o NPC.');
+    }
+};
+
+Blockly.JavaScript['cond_ispc'] = function (block) {
+    const variable = block.getFieldValue('VAR');
+    const tipo = block.getFieldValue('TIPO');
+    return [`${tipo} ${variable}`, Blockly.JavaScript.ORDER_NONE];
+};
+
+Blockly.Blocks['cond_level'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('el nivel de')
+            .appendField(new Blockly.FieldDropdown(opcionesVariables()), 'VAR')
+            .appendField(new Blockly.FieldDropdown([
+                ['=', '=='],
+                ['!=', '!='],
+                ['>', '>'],
+                ['<', '<'],
+                ['>=', '>='],
+                ['<=', '<=']
+            ]), 'OP')
+            .appendField(new Blockly.FieldNumber(0, 0, 200), 'NUM');
+        this.setOutput(true, 'Boolean');
+        this.setColour(COLORES.condiciones);
+        this.setTooltip('Compara el nivel del personaje indicado.');
+    }
+};
+
+Blockly.JavaScript['cond_level'] = function (block) {
+    const variable = block.getFieldValue('VAR');
+    const op = block.getFieldValue('OP');
+    const num = block.getFieldValue('NUM');
+    return [`level ${variable} ${op} ${num}`, Blockly.JavaScript.ORDER_NONE];
+};
+
+Blockly.Blocks['cond_alineacion'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('la alineación de')
+            .appendField(new Blockly.FieldDropdown(opcionesVariables()), 'VAR')
+            .appendField('es')
+            .appendField(new Blockly.FieldDropdown([
+                ['buena', 'isgood'],
+                ['neutral', 'isneutral'],
+                ['mala', 'isevil']
+            ]), 'AL');
+        this.setOutput(true, 'Boolean');
+        this.setColour(COLORES.condiciones);
+        this.setTooltip('Verifica la alineación del personaje.');
+    }
+};
+
+Blockly.JavaScript['cond_alineacion'] = function (block) {
+    const variable = block.getFieldValue('VAR');
+    const al = block.getFieldValue('AL');
+    return [`${al} ${variable}`, Blockly.JavaScript.ORDER_NONE];
+};
+
+Blockly.Blocks['cond_carries'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField(new Blockly.FieldDropdown(opcionesVariables()), 'VAR')
+            .appendField('lleva el objeto')
+            .appendField(new Blockly.FieldTextInput('vnum'), 'OBJ');
+        this.setOutput(true, 'Boolean');
+        this.setColour(COLORES.condiciones);
+        this.setTooltip('Comprueba si el personaje lleva un objeto.');
+    }
+};
+
+Blockly.JavaScript['cond_carries'] = function (block) {
+    const variable = block.getFieldValue('VAR');
+    const obj = block.getFieldValue('OBJ');
+    return [`carries ${variable} ${obj}`, Blockly.JavaScript.ORDER_NONE];
+};
+
+Blockly.Blocks['cond_pquestactiva'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('la quest')
+            .appendField(new Blockly.FieldTextInput('nombre'), 'QUEST')
+            .appendField('está activa para')
+            .appendField(new Blockly.FieldDropdown(opcionesVariables()), 'VAR');
+        this.setOutput(true, 'Boolean');
+        this.setColour(COLORES.condiciones);
+        this.setTooltip('Verifica si una quest está activa.');
+    }
+};
+
+Blockly.JavaScript['cond_pquestactiva'] = function (block) {
+    const quest = block.getFieldValue('QUEST');
+    const variable = block.getFieldValue('VAR');
+    return [`pquestactiva ${variable} '${quest}'`, Blockly.JavaScript.ORDER_NONE];
+};
+
+Blockly.Blocks['cond_pquestfase'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('la quest')
+            .appendField(new Blockly.FieldTextInput('nombre'), 'QUEST')
+            .appendField('está en fase')
+            .appendField(new Blockly.FieldNumber(1, 0, 100), 'FASE')
+            .appendField('para')
+            .appendField(new Blockly.FieldDropdown(opcionesVariables()), 'VAR');
+        this.setOutput(true, 'Boolean');
+        this.setColour(COLORES.condiciones);
+        this.setTooltip('Comprueba la fase de una quest.');
+    }
+};
+
+Blockly.JavaScript['cond_pquestfase'] = function (block) {
+    const quest = block.getFieldValue('QUEST');
+    const fase = block.getFieldValue('FASE');
+    const variable = block.getFieldValue('VAR');
+    return [`pquestfase ${variable} '${quest}' ${fase}`, Blockly.JavaScript.ORDER_NONE];
+};
+
+Blockly.Blocks['cond_pquestfin'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('la quest')
+            .appendField(new Blockly.FieldTextInput('nombre'), 'QUEST')
+            .appendField('está finalizada para')
+            .appendField(new Blockly.FieldDropdown(opcionesVariables()), 'VAR');
+        this.setOutput(true, 'Boolean');
+        this.setColour(COLORES.condiciones);
+        this.setTooltip('Comprueba si una quest ha finalizado.');
+    }
+};
+
+Blockly.JavaScript['cond_pquestfin'] = function (block) {
+    const quest = block.getFieldValue('QUEST');
+    const variable = block.getFieldValue('VAR');
+    return [`pquestfin ${variable} '${quest}'`, Blockly.JavaScript.ORDER_NONE];
+};
+
+// Bloques de Acción
+Blockly.Blocks['action_echo'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('decir a todos en la sala:')
+            .appendField(new Blockly.FieldTextInput('texto'), 'TEXTO');
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+        this.setColour(COLORES.acciones);
+        this.setTooltip('Muestra un mensaje a todos en la sala.');
+    }
+};
+
+Blockly.JavaScript['action_echo'] = function (block) {
+    const texto = block.getFieldValue('TEXTO');
+    const tipo = block.workspace.programType;
+    return `${tipo} echo ${texto}\n`;
+};
+
+Blockly.Blocks['action_echoat'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('decir solo a')
+            .appendField(new Blockly.FieldDropdown(opcionesVariables()), 'VAR')
+            .appendField(':')
+            .appendField(new Blockly.FieldTextInput('texto'), 'TEXTO');
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+        this.setColour(COLORES.acciones);
+        this.setTooltip('Envía un mensaje solo al personaje indicado.');
+    }
+};
+
+Blockly.JavaScript['action_echoat'] = function (block) {
+    const variable = block.getFieldValue('VAR');
+    const texto = block.getFieldValue('TEXTO');
+    const tipo = block.workspace.programType;
+    return `${tipo} echoat ${variable} ${texto}\n`;
+};
+
+Blockly.Blocks['action_mload'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('crear el mob con VNUM')
+            .appendField(new Blockly.FieldNumber(0, 0), 'VNUM');
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+        this.setColour(COLORES.acciones);
+        this.setTooltip('Crea un mob con el VNUM dado.');
+    }
+};
+
+Blockly.JavaScript['action_mload'] = function (block) {
+    const vnum = block.getFieldValue('VNUM');
+    const tipo = block.workspace.programType;
+    return `${tipo} mload ${vnum}\n`;
+};
+
+Blockly.Blocks['action_oload'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('crear el objeto con VNUM')
+            .appendField(new Blockly.FieldNumber(0, 0), 'VNUM')
+            .appendField('y ponerlo en')
+            .appendField(new Blockly.FieldDropdown([
+                ['inventario', 'inventario'],
+                ['suelo', 'suelo'],
+                ['equipado', 'equipado']
+            ]), 'LUGAR');
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+        this.setColour(COLORES.acciones);
+        this.setTooltip('Crea un objeto y lo coloca en el lugar indicado.');
+    }
+};
+
+Blockly.JavaScript['action_oload'] = function (block) {
+    const vnum = block.getFieldValue('VNUM');
+    const lugar = block.getFieldValue('LUGAR');
+    const tipo = block.workspace.programType;
+    return `${tipo} oload ${vnum} ${lugar}\n`;
+};
+
+Blockly.Blocks['action_transfer'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('transferir a')
+            .appendField(new Blockly.FieldDropdown(opcionesVariables()), 'VAR')
+            .appendField('a la habitación VNUM')
+            .appendField(new Blockly.FieldNumber(0, 0), 'VNUM');
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+        this.setColour(COLORES.acciones);
+        this.setTooltip('Transfiere al personaje a otra habitación.');
+    }
+};
+
+Blockly.JavaScript['action_transfer'] = function (block) {
+    const variable = block.getFieldValue('VAR');
+    const vnum = block.getFieldValue('VNUM');
+    const tipo = block.workspace.programType;
+    return `${tipo} transfer ${variable} ${vnum}\n`;
+};
+
+Blockly.Blocks['action_force'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('forzar a')
+            .appendField(new Blockly.FieldDropdown(opcionesVariables()), 'VAR')
+            .appendField('a ejecutar')
+            .appendField(new Blockly.FieldTextInput('comando'), 'CMD');
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+        this.setColour(COLORES.acciones);
+        this.setTooltip('Hace que el personaje ejecute un comando.');
+    }
+};
+
+Blockly.JavaScript['action_force'] = function (block) {
+    const variable = block.getFieldValue('VAR');
+    const cmd = block.getFieldValue('CMD');
+    const tipo = block.workspace.programType;
+    return `${tipo} force ${variable} ${cmd}\n`;
+};
+
+Blockly.Blocks['action_pquestinicio'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('iniciar la quest')
+            .appendField(new Blockly.FieldTextInput('nombre'), 'QUEST')
+            .appendField('para')
+            .appendField(new Blockly.FieldDropdown(opcionesVariables()), 'VAR');
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+        this.setColour(COLORES.acciones);
+        this.setTooltip('Inicia una quest para el personaje.');
+    }
+};
+
+Blockly.JavaScript['action_pquestinicio'] = function (block) {
+    const quest = block.getFieldValue('QUEST');
+    const variable = block.getFieldValue('VAR');
+    const tipo = block.workspace.programType;
+    return `${tipo} pquestinicio ${variable} '${quest}'\n`;
+};
+
+Blockly.Blocks['action_pquestfase'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('cambiar la fase de la quest')
+            .appendField(new Blockly.FieldTextInput('nombre'), 'QUEST')
+            .appendField('a')
+            .appendField(new Blockly.FieldNumber(1, 0, 100), 'FASE')
+            .appendField('para')
+            .appendField(new Blockly.FieldDropdown(opcionesVariables()), 'VAR');
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+        this.setColour(COLORES.acciones);
+        this.setTooltip('Cambia la fase de una quest.');
+    }
+};
+
+Blockly.JavaScript['action_pquestfase'] = function (block) {
+    const quest = block.getFieldValue('QUEST');
+    const fase = block.getFieldValue('FASE');
+    const variable = block.getFieldValue('VAR');
+    const tipo = block.workspace.programType;
+    return `${tipo} pquestfase ${variable} '${quest}' ${fase}\n`;
+};
+
+Blockly.Blocks['action_pquestfin'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('finalizar la quest')
+            .appendField(new Blockly.FieldTextInput('nombre'), 'QUEST')
+            .appendField('para')
+            .appendField(new Blockly.FieldDropdown(opcionesVariables()), 'VAR');
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+        this.setColour(COLORES.acciones);
+        this.setTooltip('Finaliza una quest para el personaje.');
+    }
+};
+
+Blockly.JavaScript['action_pquestfin'] = function (block) {
+    const quest = block.getFieldValue('QUEST');
+    const variable = block.getFieldValue('VAR');
+    const tipo = block.workspace.programType;
+    return `${tipo} pquestfin ${variable} '${quest}'\n`;
+};
+
+Blockly.Blocks['action_sleep'] = {
+    init: function () {
+        this.appendDummyInput()
+            .appendField('esperar')
+            .appendField(new Blockly.FieldNumber(1, 0), 'NUM')
+            .appendField('segundos');
+        this.setPreviousStatement(true, null);
+        this.setNextStatement(true, null);
+        this.setColour(COLORES.acciones);
+        this.setTooltip('Detiene el programa durante el número de segundos indicado.');
+    }
+};
+
+Blockly.JavaScript['action_sleep'] = function (block) {
+    const num = block.getFieldValue('NUM');
+    return `sleep ${num}\n`;
+};
+
+Blockly.Blocks['action_break'] = {
+    init: function () {
+        this.appendDummyInput().appendField('detener este programa');
+        this.setPreviousStatement(true, null);
+        this.setColour(COLORES.acciones);
+        this.setTooltip('Detiene el programa de inmediato.');
+    }
+};
+
+Blockly.JavaScript['action_break'] = function () {
+    return 'break\n';
+};
+
+// Bloques de Variables
+gameData.progVariables.forEach(v => {
+    const nombre = `var_${v.value.replace('$', '')}`;
+    Blockly.Blocks[nombre] = {
+        init: function () {
+            this.appendDummyInput().appendField(v.label);
+            this.setOutput(true, null);
+            this.setColour(COLORES.variables);
+            this.setTooltip(v.label);
+        }
+    };
+    Blockly.JavaScript[nombre] = function () {
+        return [v.value, Blockly.JavaScript.ORDER_ATOMIC];
+    };
+});
+

--- a/js/config.js
+++ b/js/config.js
@@ -1338,6 +1338,18 @@ export const gameData = {
 
     shopHours: Array.from({ length: 24 }, (_, i) => ({ value: String(i), label: String(i) })),
 
+    // Variables disponibles para los bloques de Blockly en los PROGs
+    progVariables: [
+        { value: '$i', label: 'el personaje/objeto/sala actual' },
+        { value: '$n', label: 'el jugador que activó el evento' },
+        { value: '$r', label: 'un jugador al azar en la sala' },
+        { value: '$o', label: 'el objeto principal' },
+        { value: '$a', label: 'el primer texto capturado' },
+        { value: '$b', label: 'el segundo texto capturado' },
+        { value: '$u', label: 'el primer argumento de "usar"' },
+        { value: '$v', label: 'el segundo argumento de "usar"' }
+    ],
+
     // Prompts detallados para la generación de descripciones de IA.
     // Cada clave representa un tipo de entidad (mob, object, room) y contiene sub-prompts específicos.
     aiPrompts: {

--- a/js/parser.js
+++ b/js/parser.js
@@ -1,6 +1,7 @@
 import { populateAffectBitSelect, populateObjectTypeSelect, updateObjectValuesUI } from './objects.js';
 import { refrescarOpcionesResets } from './resets.js';
 import { poblarSelectsTienda } from './shops.js';
+import { initProgBlockly } from './blockly-progs.js';
 
 export function parseAreFile(content) {
     console.log('Parsing .are file...');
@@ -888,6 +889,8 @@ function populateProgsSection(progsData, containerId, templateId) {
         addedCardElement.querySelector('.prog-vnum-display').textContent = prog.vnum;
 
         container.appendChild(addedCardElement);
+        const type = containerId.replace('-container', '');
+        initProgBlockly(addedCardElement, type);
     });
 }
 

--- a/js/progs.js
+++ b/js/progs.js
@@ -1,8 +1,20 @@
 import { setupDynamicSection } from './utils.js';
+import { initProgBlockly } from './blockly-progs.js';
 
 export function setupProgsSection(type, vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector) {
     const buttonType = type.replace('s', '');
-    setupDynamicSection(`add-${buttonType}-btn`, `${type}-container`, 'prog-template', '.prog-card', vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector);
+    setupDynamicSection(
+        `add-${buttonType}-btn`,
+        `${type}-container`,
+        'prog-template',
+        '.prog-card',
+        vnumRangeCheckFunction,
+        vnumSelector,
+        vnumDisplaySelector,
+        nameInputSelector,
+        nameDisplaySelector,
+        card => initProgBlockly(card, type)
+    );
 }
 
 export function generateProgsSection(containerId, sectionName) {

--- a/resumen.md
+++ b/resumen.md
@@ -64,3 +64,8 @@
     *   **Comentarios de Tienda**: Cada tienda puede incluir un comentario opcional; si se especifica, se añade tras un `*` en la línea generada.
     *   **Encabezado con comentario**: El comentario de cada tienda se refleja en el título de la tarjeta para reconocerla cuando está contraída.
     *   **Parser y Generación Corregidos**: Se actualizó el formato de lectura y escritura para que cada tienda se procese en una sola línea conforme a la documentación.
+
+*   **Editor Visual para Progs**:
+    *   Se integró Blockly para construir MOBPROGS, OBJPROGS y ROOMPROGS mediante bloques visuales.
+    *   Se añadió el módulo `js/blockly-progs.js` y se adaptaron `index.html`, `js/progs.js` y `js/parser.js` para actualizar el código de los progs desde un área de trabajo gráfico.
+    *   El editor se muestra ahora en una ventana modal de pantalla completa con bloques coloreados por categoría y ofrece una vista del código generado.

--- a/style.css
+++ b/style.css
@@ -402,3 +402,49 @@ select:focus {
 .shop-form-layout .form-inline label {
     margin-bottom: 0.5rem; /* Add margin back to labels in inline groups */
 }
+
+/* Modal para Blockly */
+#blockly-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+#blockly-modal[hidden] {
+    display: none;
+}
+
+#blockly-modal .modal-contenido {
+    background: var(--secondary-color);
+    width: 90%;
+    height: 90%;
+    display: flex;
+    flex-direction: column;
+    padding: 10px;
+}
+
+#blockly-workspace {
+    flex: 1;
+}
+
+#blockly-modal .modal-controles {
+    margin-top: 8px;
+    text-align: right;
+}
+
+.prog-summary {
+    margin-bottom: 8px;
+}
+
+.prog-code-display {
+    background: var(--secondary-color);
+    padding: 5px;
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
## Resumen
- El editor Blockly de los PROGs se abre ahora en una ventana modal a pantalla completa con resumen y vista de código.
- Los bloques se agrupan por categoría con colores propios y se guardan tanto el código como el XML para reabrirlos.
- Se añadieron estilos y documentación para reflejar el nuevo funcionamiento.

## Pruebas
- `node -v`
- `npm test` *(falla: no existe package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bace602f40832d9555d8cf0d6b13fb