### PR TITLE
Mostrar comentario de specials en encabezado

### DIFF
--- a/index.html
+++ b/index.html
@@ -2153,11 +2153,11 @@
             <div class="collapsible-header">
                 <h4>
                     Especial:
-                    <span class="special-name-display">
-                    </span>
+                    <span class="special-comment-display"></span>
+                    <span class="special-hyphen" style="display: none;"> - </span>
+                    <span class="special-name-display"></span>
                     | Vnum:
-                    <span class="special-vnum-display">
-                    </span>
+                    <span class="special-vnum-display"></span>
                 </h4>
             </div>
             <div class="collapsible-content">

--- a/instrucciones.md
+++ b/instrucciones.md
@@ -206,6 +206,7 @@ La aplicación debe permitir definir múltiples especiales. Cada especial tendr�
     *   Se elige desde un menú desplegable alimentado por `js/config.js`, donde cada opción muestra un *tooltip* con su descripción.
     *   Lista de especiales: `spec_troll_member`, `spec_ogre_member`, `spec_patrolman`, `spec_nasty`, `spec_breath_any` (y específicos por elemento como `_acid`, `_fire`, etc.), `spec_cast_adepto`, `spec_cast_clerigo`, `spec_cast_mago`, `spec_fido`, `spec_guard`, `spec_janitor`, `spec_alcalde`, `spec_veneno`, `spec_ladron`, `spec_cast_runk`, `spec_cast_oteren`, `spec_guardia_malo`, `spec_guardia_bueno`, `spec_teleporter`, `spec_barco`, `spec_esfinge`, `spec_guardia_clan`, `spec_entrenador_especial`, `spec_quest_especial_1`, `spec_quest_especial_2`, `spec_secretario`, `spec_mordisco`, `spec_entrenador_samurai`, `spec_samu_experto_1`, `spec_samu_experto_2`.
 *   **Comentario** (Opcional): Empieza con `*` (ej. `* Los lagartos`).
+*   **Visibilidad en la Tarjeta**: Al contraer la tarjeta se muestra el comentario (sin el `*`) seguido del nombre del especial para identificarlo rápidamente.
 *   **Regla**: Un mob solo puede tener un especial asignado.
 *   Finaliza con `S` para la sección completa.
 

--- a/js/parser.js
+++ b/js/parser.js
@@ -844,12 +844,12 @@ function populateSpecialsSection(specialsData) {
         const select = addedCardElement.querySelector('.special-name');
         select.value = special.type;
         select.dispatchEvent(new Event('change'));
-        select.dispatchEvent(new Event('input'));
+        const commentInput = addedCardElement.querySelector('.special-comment');
         if (special.comment) {
-            addedCardElement.querySelector('.special-comment').value = special.comment;
+            commentInput.value = special.comment;
         }
+        commentInput.dispatchEvent(new Event('input'));
         addedCardElement.querySelector('.special-vnum-display').textContent = special.vnumMob;
-        addedCardElement.querySelector('.special-name-display').textContent = special.type;
 
         container.appendChild(addedCardElement);
     });

--- a/js/specials.js
+++ b/js/specials.js
@@ -3,6 +3,10 @@ import { gameData } from './config.js';
 
 export function poblarSelectEspecial(card) {
     const select = card.querySelector('.special-name');
+    const nameDisplay = card.querySelector('.special-name-display');
+    const commentInput = card.querySelector('.special-comment');
+    const commentDisplay = card.querySelector('.special-comment-display');
+    const hyphenSpan = card.querySelector('.special-hyphen');
     if (!select) return;
     select.innerHTML = '';
     const placeholder = document.createElement('option');
@@ -19,7 +23,17 @@ export function poblarSelectEspecial(card) {
     select.addEventListener('change', () => {
         const seleccionado = gameData.specials.find(s => s.value === select.value);
         select.title = seleccionado ? seleccionado.descripcion : '';
+        if (nameDisplay) nameDisplay.textContent = select.value;
     });
+
+    if (commentInput && commentDisplay && hyphenSpan) {
+        commentInput.addEventListener('input', () => {
+            const texto = commentInput.value.replace(/^\*\s*/, '');
+            commentDisplay.textContent = texto;
+            hyphenSpan.style.display = texto ? '' : 'none';
+        });
+        commentInput.dispatchEvent(new Event('input'));
+    }
 }
 
 export function setupSpecialsSection(vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector) {

--- a/resumen.md
+++ b/resumen.md
@@ -71,6 +71,7 @@
 *   **Mejoras en la Sección Specials**:
     *   **Desplegable de Especiales con Tooltips**: El tipo de especial ahora se elige desde un `<select>` poblado dinámicamente con `js/config.js`, mostrando un tooltip explicativo para cada opción.
     *   **Lista Centralizada de Especiales**: Se añadió `gameData.specials` con todos los nombres y descripciones, eliminando el `<datalist>` embebido en `index.html`.
+    *   **Comentario en Encabezado**: El comentario opcional se muestra junto al nombre del especial en el título de la tarjeta para reconocerlo cuando está contraída.
 *   **Editor Visual para Progs**:
     *   Se integró Blockly para construir MOBPROGS, OBJPROGS y ROOMPROGS mediante bloques visuales.
     *   Se añadió el módulo `js/blockly-progs.js` y se adaptaron `index.html`, `js/progs.js` y `js/parser.js` para actualizar el código de los progs desde un área de trabajo gráfico.

--- a/script.js
+++ b/script.js
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
     refrescarOpcionesResets();
     setupSetSection(null, '.set-id', '.set-id-display', '.set-name', '.set-name-display');
     setupShopsSection(isValidVnumRange, '.shop-vnum', '.shop-vnum-display', '.shop-comment', '.shop-comment-display');
-    setupSpecialsSection(isValidVnumRange, '.special-vnum', '.special-vnum-display', '.special-name', '.special-name-display');
+    setupSpecialsSection(isValidVnumRange, '.special-vnum', '.special-vnum-display', null, null);
     setupProgsSection('mobprogs', isValidVnumRange, '.prog-vnum', '.prog-vnum-display', null, null);
     setupProgsSection('objprogs', isValidVnumRange, '.prog-vnum', '.prog-vnum-display', null, null);
     setupProgsSection('roomprogs', isValidVnumRange, '.prog-vnum', '.prog-vnum-display', null, null);


### PR DESCRIPTION
## Resumen
- Mostrar el comentario opcional junto al nombre del special en la cabecera de cada tarjeta
- Ajustar parser y plantilla para manejar comentario y guion
- Documentar la visibilidad del comentario en instrucciones y resumen

## Pruebas
- `npm test` (falla: no existe package.json)


------
https://chatgpt.com/codex/tasks/task_e_68badfc1b1d4832d935ba021c372e07e