### PR TITLE
Corrige edición y generación de progs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2186,8 +2186,8 @@
     </template>
     <template id="prog-template">
         <div class="prog-card simple-card">
-            <button class="remove-btn">
-                X
+            <button type="button" class="remove-btn">
+                🗑️
             </button>
             <div class="collapsible-header">
                 <h4>

--- a/instrucciones.md
+++ b/instrucciones.md
@@ -298,3 +298,11 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 
 **Nota Adicional para la IA:** El foco principal es la **generación precisa del formato del archivo `.are`**. La lógica interna de los `MOBPROGS` es compleja y su validación completa no es el objetivo inicial, sino permitir su entrada como texto. Las tablas y flags deben estar presentes para que el usuario pueda seleccionarlos o introducirlos, y la salida generada debe ser conforme a estas definiciones.
 
+---
+
+### Cambios recientes
+
+- Se conectaron los controles de la ventana Blockly para que los botones **Guardar** y **Cerrar** funcionen correctamente.
+- Las categorías del editor (Eventos, Condiciones, Acciones, Lógica y Variables) ahora muestran colores diferenciados y legibles.
+- La generación de secciones `#MOBPROGS`, `#OBJPROGS` y `#ROOMPROGS` añade un salto de línea antes del `~` final, evitando la pérdida del último comando.
+

--- a/js/blockly-progs.js
+++ b/js/blockly-progs.js
@@ -1,11 +1,13 @@
 import { gameData } from './config.js';
 
+// Blockly espera colores en formato de matiz (0-360). Usar números
+// evita que todas las categorías se vean del mismo verde por defecto.
 const COLORES = {
-    eventos: '#5C81A6',
-    condiciones: '#5CA65C',
-    acciones: '#A65C81',
-    logica: '#9A5CA6',
-    variables: '#A6745C'
+    eventos: 210,        // Azul
+    condiciones: 120,    // Verde
+    acciones: 330,       // Rosa/morado
+    logica: 290,         // Violeta
+    variables: 20        // Naranja
 };
 
 let espacioTrabajo = null;
@@ -106,8 +108,15 @@ function guardarModal() {
     cerrarModal();
 }
 
-document.getElementById('blockly-close').addEventListener('click', cerrarModal);
-document.getElementById('blockly-save').addEventListener('click', guardarModal);
+// Se exporta una función para enlazar los controles del modal una vez que
+// el DOM está cargado. Antes se realizaba en la carga del módulo y fallaba
+// porque los botones aún no existían.
+export function initBlocklyModalControls() {
+    const btnCerrar = document.getElementById('blockly-close');
+    const btnGuardar = document.getElementById('blockly-save');
+    if (btnCerrar) btnCerrar.addEventListener('click', cerrarModal);
+    if (btnGuardar) btnGuardar.addEventListener('click', guardarModal);
+}
 
 export function initProgBlockly(tarjeta, tipoSeccion) {
     const btnEditar = tarjeta.querySelector('.edit-prog-btn');

--- a/js/progs.js
+++ b/js/progs.js
@@ -25,7 +25,8 @@ export function generateProgsSection(containerId, sectionName) {
         const vnum = card.querySelector('.prog-vnum').value;
         const code = card.querySelector('.prog-code').value;
         if (vnum && code) {
-            section += `#${vnum}\n${code}~\n`;
+            const codeBlock = code.endsWith('\n') ? code : `${code}\n`;
+            section += `#${vnum}\n${codeBlock}~\n`;
         }
     });
     return section + '#0\n\n';

--- a/resumen.md
+++ b/resumen.md
@@ -64,10 +64,6 @@
     *   **Comentarios de Tienda**: Cada tienda puede incluir un comentario opcional; si se especifica, se añade tras un `*` en la línea generada.
     *   **Encabezado con comentario**: El comentario de cada tienda se refleja en el título de la tarjeta para reconocerla cuando está contraída.
     *   **Parser y Generación Corregidos**: Se actualizó el formato de lectura y escritura para que cada tienda se procese en una sola línea conforme a la documentación.
-*   **Editor Visual para Progs**:
-    *   Se integró Blockly para construir MOBPROGS, OBJPROGS y ROOMPROGS mediante bloques visuales.
-    *   Se añadió el módulo `js/blockly-progs.js` y se adaptaron `index.html`, `js/progs.js` y `js/parser.js` para actualizar el código de los progs desde un área de trabajo gráfico.
-    *   El editor se muestra ahora en una ventana modal de pantalla completa con bloques coloreados por categoría y ofrece una vista del código generado.
 *   **Mejoras en la Sección Specials**:
     *   **Desplegable de Especiales con Tooltips**: El tipo de especial ahora se elige desde un `<select>` poblado dinámicamente con `js/config.js`, mostrando un tooltip explicativo para cada opción.
     *   **Lista Centralizada de Especiales**: Se añadió `gameData.specials` con todos los nombres y descripciones, eliminando el `<datalist>` embebido en `index.html`.
@@ -75,3 +71,8 @@
 *   **Editor Visual para Progs**:
     *   Se integró Blockly para construir MOBPROGS, OBJPROGS y ROOMPROGS mediante bloques visuales.
     *   Se añadió el módulo `js/blockly-progs.js` y se adaptaron `index.html`, `js/progs.js` y `js/parser.js` para actualizar el código de los progs desde un área de trabajo gráfico.
+    *   El editor se muestra ahora en una ventana modal de pantalla completa con bloques coloreados por categoría y ofrece una vista del código generado.
+*   **Correcciones en Progs**:
+    *   Los botones **Guardar** y **Cerrar** del editor visual ahora se enlazan tras la carga del DOM y funcionan correctamente.
+    *   Cada categoría de bloques (Eventos, Condiciones, Acciones, Lógica y Variables) usa un color propio para facilitar su identificación.
+    *   Al generar el archivo `.are`, el código de los progs incluye un salto de línea antes del delimitador `~`, preservando el último comando.

--- a/script.js
+++ b/script.js
@@ -7,6 +7,7 @@ import { setupSetSection, generateSetSection } from './js/sets.js';
 import { setupShopsSection, generateShopsSection } from './js/shops.js';
 import { setupSpecialsSection, generateSpecialsSection } from './js/specials.js';
 import { setupProgsSection, generateProgsSection } from './js/progs.js';
+import { initBlocklyModalControls } from './js/blockly-progs.js';
 import { gameData } from './js/config.js';
 import { parseAreFile } from './js/parser.js';
 
@@ -50,6 +51,9 @@ document.addEventListener('DOMContentLoaded', () => {
     setupProgsSection('roomprogs', isValidVnumRange, '.prog-vnum', '.prog-vnum-display', null, null);
 
     populateMaterialsDatalist(); // Call the new function here
+
+    // Enlazar controles del editor de bloques
+    initBlocklyModalControls();
 
     // Setup main generate button
     document.getElementById('generate-btn').addEventListener('click', generateAreFile);

--- a/style.css
+++ b/style.css
@@ -415,6 +415,7 @@ select:focus {
     align-items: center;
     justify-content: center;
     z-index: 1000;
+    color: initial; /* Evita el verde global en la interfaz de Blockly */
 }
 
 #blockly-modal[hidden] {
@@ -447,4 +448,10 @@ select:focus {
     background: var(--secondary-color);
     padding: 5px;
     white-space: pre-wrap;
+}
+
+/* Las etiquetas del árbol de categorías heredan el color asignado por Blockly */
+#blockly-modal .blocklyTreeRow,
+#blockly-modal .blocklyTreeLabel {
+    color: inherit !important;
 }


### PR DESCRIPTION
## Resumen
- Ajusté los colores de las categorías del editor Blockly usando matices numéricos y eliminé el tinte verde global.
- Enlacé correctamente los botones Guardar y Cerrar del modal para que guarden el código de los progs.
- Aseguré la generación correcta de MOBPROGS, OBJPROGS y ROOMPROGS agregando un salto de línea antes del `~` final y mejoré la interfaz con un botón de papelera claro.

## Pruebas
- `npm test` *(falla: no existe package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bae29bb950832dbdcd4dde114a928d