### PR TITLE
Corrige categoría Eventos en editor de progs

### DIFF
--- a/instrucciones.md
+++ b/instrucciones.md
@@ -305,4 +305,5 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Se conectaron los controles de la ventana Blockly para que los botones **Guardar** y **Cerrar** funcionen correctamente.
 - Las categorías del editor (Eventos, Condiciones, Acciones, Lógica y Variables) ahora muestran colores diferenciados y legibles.
 - La generación de secciones `#MOBPROGS`, `#OBJPROGS` y `#ROOMPROGS` añade un salto de línea antes del `~` final, evitando la pérdida del último comando.
+- Se corrigió la categoría **Eventos** del editor visual, reemplazando el método obsoleto `setHat` por la propiedad `hat` para que los bloques se muestren correctamente.
 

--- a/js/blockly-progs.js
+++ b/js/blockly-progs.js
@@ -145,7 +145,7 @@ Blockly.Blocks['event_speech'] = {
         this.appendStatementInput('CUERPO').setCheck(null).appendField('hacer');
         this.setColour(COLORES.eventos);
         this.setTooltip('Se activa cuando un jugador dice la palabra o frase especificada en la misma habitación.');
-        this.setHat('cap');
+        this.hat = 'cap';
     }
 };
 
@@ -163,7 +163,7 @@ Blockly.Blocks['event_act'] = {
         this.appendStatementInput('CUERPO').setCheck(null).appendField('hacer');
         this.setColour(COLORES.eventos);
         this.setTooltip('Se activa cuando en la habitación ocurre una acción que contiene el texto indicado.');
-        this.setHat('cap');
+        this.hat = 'cap';
     }
 };
 
@@ -181,7 +181,7 @@ Blockly.Blocks['event_random'] = {
         this.appendStatementInput('CUERPO').setCheck(null).appendField('hacer');
         this.setColour(COLORES.eventos);
         this.setTooltip('Se activa al azar según el porcentaje indicado.');
-        this.setHat('cap');
+        this.hat = 'cap';
     }
 };
 
@@ -204,7 +204,7 @@ Blockly.Blocks['event_greet'] = {
         this.appendStatementInput('CUERPO').setCheck(null).appendField('hacer');
         this.setColour(COLORES.eventos);
         this.setTooltip('Se activa cuando cualquier personaje entra en la habitación.');
-        this.setHat('cap');
+        this.hat = 'cap';
     }
 };
 
@@ -223,7 +223,7 @@ Blockly.Blocks['event_give'] = {
         this.appendStatementInput('CUERPO').setCheck(null).appendField('hacer');
         this.setColour(COLORES.eventos);
         this.setTooltip('Se activa cuando un jugador da un objeto específico.');
-        this.setHat('cap');
+        this.hat = 'cap';
     }
 };
 

--- a/resumen.md
+++ b/resumen.md
@@ -76,3 +76,4 @@
     *   Los botones **Guardar** y **Cerrar** del editor visual ahora se enlazan tras la carga del DOM y funcionan correctamente.
     *   Cada categoría de bloques (Eventos, Condiciones, Acciones, Lógica y Variables) usa un color propio para facilitar su identificación.
     *   Al generar el archivo `.are`, el código de los progs incluye un salto de línea antes del delimitador `~`, preservando el último comando.
+    *   La categoría **Eventos** del editor visual vuelve a mostrar sus bloques al sustituir el método `setHat` por la propiedad `hat`.


### PR DESCRIPTION
## Resumen
- Reemplazo de `setHat` por la propiedad `hat` en los bloques de eventos para evitar fallos al abrir la categoría.
- Documentación actualizada en `instrucciones.md` y `resumen.md` para reflejar la corrección.

## Pruebas
- `node --check js/blockly-progs.js`
- `npm test` *(falló: no se encontró `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68bae52c8344832d9dcb43c3c108d18b