### PR TITLE
Relleno de listas al importar mobs

### DIFF
--- a/instrucciones.md
+++ b/instrucciones.md
@@ -305,4 +305,5 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Se corrigió la carga de archivos `.are` ajustando el parser para detectar solo las secciones principales y respetar los delimitadores internos como `#0` y `~`.
 - Se mejoró el análisis de la sección `#AREA` para extraer correctamente el rango de niveles, el creador, los VNUMs y la región aun con formatos variables.
 - Se corrigió la importación de la sección `#MOBILES` para reconocer descripciones multilínea, dados y flags en una sola línea.
+- Se rellenaron los desplegables de raza y tipo de daño al importar mobs desde archivos `.are`.
 

--- a/js/parser.js
+++ b/js/parser.js
@@ -2,6 +2,7 @@ import { populateAffectBitSelect, populateObjectTypeSelect, updateObjectValuesUI
 import { refrescarOpcionesResets } from './resets.js';
 import { poblarSelectsTienda } from './shops.js';
 import { poblarSelectEspecial } from './specials.js';
+import { gameData } from './config.js';
 
 export function parseAreFile(content) {
     console.log('Parsing .are file...');
@@ -260,6 +261,27 @@ function populateMobilesSection(mobilesData) {
     mobilesData.forEach(mob => {
         const newCard = template.content.cloneNode(true);
         const addedCardElement = newCard.querySelector('.mob-card');
+
+        // Poblar listas desplegables de raza y tipo de daño antes de asignar valores
+        const raceSelect = addedCardElement.querySelector('.mob-race');
+        if (raceSelect) {
+            gameData.races.forEach(race => {
+                const option = document.createElement('option');
+                option.value = race;
+                option.textContent = race;
+                raceSelect.appendChild(option);
+            });
+        }
+
+        const damageTypeSelect = addedCardElement.querySelector('.mob-dam-type');
+        if (damageTypeSelect) {
+            gameData.damageTypes.forEach(type => {
+                const option = document.createElement('option');
+                option.value = type.value;
+                option.textContent = type.description;
+                damageTypeSelect.appendChild(option);
+            });
+        }
 
         addedCardElement.querySelector('.mob-vnum').value = mob.vnum;
         addedCardElement.querySelector('.mob-keywords').value = mob.keywords;

--- a/resumen.md
+++ b/resumen.md
@@ -13,6 +13,7 @@
     *   **Auto-rellenado de Hitroll**: Se implementó la funcionalidad de auto-rellenado para el campo '+Hitroll' de los mobs. Se añadió una tabla de recomendaciones (`hitrollRecommendations`) a `js/config.js` y se desarrolló la lógica en `js/mobiles.js` para calcular el hitroll sugerido basándose en el nivel del mob, utilizando interpolación lineal para los rangos.
     *   **Auto-rellenado de HP, Mana, Armaduras y Daño**: Se añadió una tabla de recomendaciones (`mobStatsRecommendations`) a `js/config.js` para los valores de HP, Mana, Armaduras y Daño por nivel. Se modificó `js/mobiles.js` para auto-rellenar estos campos basándose en el nivel del mob. El cálculo de Mana se ajustó para seguir la fórmula `1d10 + 100 * Nivel`, y la Armadura Mágica se calcula con la fórmula `((ac - 10) / 3) + 10`.
     *   **Importación completa de mobs**: Se corrigió el parser para cargar la sección `#MOBILES`, soportando descripciones multilínea, separación de dados y flags en una sola línea.
+    *   **Listas de Raza y Tipo de Daño al Importar**: Al cargar un archivo `.are`, los desplegables de raza y tipo de daño se rellenan con `gameData` y se seleccionan los valores correspondientes de cada mob.
 *   **Mejoras en la Sección Objects**:
     *   **Campo Material (Datalist)**:
         *   **Funcionalidad**: Se implementó un campo de entrada para "Material" que permite seleccionar de una lista de sugerencias o escribir un valor personalizado. Esto se logró utilizando un elemento `<datalist>` en `index.html` vinculado al campo de entrada.


### PR DESCRIPTION
## Resumen
- Se poblaron los desplegables de raza y tipo de daño al cargar mobs desde archivos `.are`
- Se documentó la mejora en instrucciones y resumen del proyecto

## Pruebas
- `npm test` (falla: no existe package.json)
- `node --check js/parser.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb03280940832da31178d0f396ef89