### PR TITLE
Avisos integrales al importar mobs y restauración de colapsado

### DIFF
--- a/instrucciones.md
+++ b/instrucciones.md
@@ -306,4 +306,7 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Se mejoró el análisis de la sección `#AREA` para extraer correctamente el rango de niveles, el creador, los VNUMs y la región aun con formatos variables.
 - Se corrigió la importación de la sección `#MOBILES` para reconocer descripciones multilínea, dados y flags en una sola línea.
 - Se rellenaron los desplegables de raza y tipo de daño al importar mobs desde archivos `.are`.
+- Se reactivó la capacidad de colapsar las tarjetas de mobs importados y el autoajuste de estadísticas al modificar el nivel.
+- Se ampliaron las advertencias al importar mobs para revisar todas las listas y flags, notificando valores desconocidos en raza, tipo de daño, posiciones, sexo, tamaño y flags.
+- Al importar un área se actualiza el aviso del rango de VNUMs, ocultando la advertencia cuando el rango es válido.
 

--- a/js/mobiles.js
+++ b/js/mobiles.js
@@ -2,136 +2,156 @@ import { setupDynamicSection, getFlagString } from './utils.js';
 import { gameData } from './config.js';
 import { refrescarOpcionesResets } from './resets.js';
 
+export function inicializarTarjetaMob(cardElement) {
+    const levelInput = cardElement.querySelector('.mob-level');
+    const hitrollInput = cardElement.querySelector('.mob-hitroll');
+    const hpDiceNumInput = cardElement.querySelector('.mob-hp-dice-num');
+    const hpDiceSidesInput = cardElement.querySelector('.mob-hp-dice-sides');
+    const hpDiceBonusInput = cardElement.querySelector('.mob-hp-dice-bonus');
+    const manaDiceNumInput = cardElement.querySelector('.mob-mana-dice-num');
+    const manaDiceSidesInput = cardElement.querySelector('.mob-mana-dice-sides');
+    const manaDiceBonusInput = cardElement.querySelector('.mob-mana-dice-bonus');
+    const damDiceNumInput = cardElement.querySelector('.mob-dam-dice-num');
+    const damDiceSidesInput = cardElement.querySelector('.mob-dam-dice-sides');
+    const damDiceBonusInput = cardElement.querySelector('.mob-dam-dice-bonus');
+    const acPierceInput = cardElement.querySelector('.mob-ac-pierce');
+    const acBashInput = cardElement.querySelector('.mob-ac-bash');
+    const acSlashInput = cardElement.querySelector('.mob-ac-slash');
+    const acMagicInput = cardElement.querySelector('.mob-ac-magic');
+
+    const updateMobStats = () => {
+        const level = parseInt(levelInput.value);
+        if (isNaN(level)) {
+            hitrollInput.value = '';
+            hpDiceNumInput.value = '';
+            hpDiceSidesInput.value = '';
+            hpDiceBonusInput.value = '';
+            manaDiceNumInput.value = '';
+            manaDiceSidesInput.value = '';
+            manaDiceBonusInput.value = '';
+            damDiceNumInput.value = '';
+            damDiceSidesInput.value = '';
+            damDiceBonusInput.value = '';
+            acPierceInput.value = '';
+            acBashInput.value = '';
+            acSlashInput.value = '';
+            acMagicInput.value = '';
+            return;
+        }
+
+        let recommendedHitroll = 0;
+        for (const rec of gameData.hitrollRecommendations) {
+            if (level >= rec.levelStart && level <= rec.levelEnd) {
+                const levelRatio = (level - rec.levelStart) / (rec.levelEnd - rec.levelStart);
+                recommendedHitroll = Math.round(rec.hitrollMin + levelRatio * (rec.hitrollMax - rec.hitrollMin));
+                break;
+            } else if (level < rec.levelStart) {
+                recommendedHitroll = rec.hitrollMin;
+                break;
+            } else if (level > gameData.hitrollRecommendations[gameData.hitrollRecommendations.length - 1].levelEnd) {
+                recommendedHitroll = gameData.hitrollRecommendations[gameData.hitrollRecommendations.length - 1].hitrollMax;
+                break;
+            }
+        }
+        hitrollInput.value = recommendedHitroll;
+
+        let mobStats = null;
+        for (let i = gameData.mobStatsRecommendations.length - 1; i >= 0; i--) {
+            if (level >= gameData.mobStatsRecommendations[i].level) {
+                mobStats = gameData.mobStatsRecommendations[i];
+                break;
+            }
+        }
+
+        if (mobStats) {
+            hpDiceNumInput.value = mobStats.hpManaDice.num;
+            hpDiceSidesInput.value = mobStats.hpManaDice.sides;
+            hpDiceBonusInput.value = mobStats.hpManaDice.bonus;
+
+            manaDiceNumInput.value = 1;
+            manaDiceSidesInput.value = 10;
+            manaDiceBonusInput.value = 100 * level;
+
+            damDiceNumInput.value = mobStats.damageDice.num;
+            damDiceSidesInput.value = mobStats.damageDice.sides;
+            damDiceBonusInput.value = mobStats.damageDice.bonus;
+
+            acPierceInput.value = mobStats.armor;
+            acBashInput.value = mobStats.armor;
+            acSlashInput.value = mobStats.armor;
+
+            const ac = parseInt(mobStats.armor);
+            if (!isNaN(ac)) {
+                acMagicInput.value = Math.round(((ac - 10) / 3) + 10);
+            }
+        } else {
+            const firstStats = gameData.mobStatsRecommendations[0];
+            hpDiceNumInput.value = firstStats.hpManaDice.num;
+            hpDiceSidesInput.value = firstStats.hpManaDice.sides;
+            hpDiceBonusInput.value = firstStats.hpManaDice.bonus;
+
+            manaDiceNumInput.value = firstStats.hpManaDice.num;
+            manaDiceSidesInput.value = firstStats.hpManaDice.sides;
+            manaDiceBonusInput.value = firstStats.hpManaDice.bonus;
+
+            damDiceNumInput.value = firstStats.damageDice.num;
+            damDiceSidesInput.value = firstStats.damageDice.sides;
+            damDiceBonusInput.value = firstStats.damageDice.bonus;
+
+            acPierceInput.value = firstStats.armor;
+            acBashInput.value = firstStats.armor;
+            acSlashInput.value = firstStats.armor;
+
+            const ac = parseInt(firstStats.armor);
+            if (!isNaN(ac)) {
+                acMagicInput.value = Math.round(((ac - 10) / 3) + 10);
+            }
+        }
+    };
+
+    if (levelInput) {
+        levelInput.addEventListener('input', updateMobStats);
+        updateMobStats();
+    }
+
+    const header = cardElement.querySelector('.collapsible-header');
+    const content = cardElement.querySelector('.collapsible-content');
+    if (header && content && !header.dataset.colapsado) {
+        header.addEventListener('click', () => {
+            content.classList.toggle('collapsed');
+        });
+        header.dataset.colapsado = 'true';
+    }
+
+    const vnumInput = cardElement.querySelector('.mob-vnum');
+    const vnumDisplay = cardElement.querySelector('.mob-vnum-display');
+    if (vnumInput && vnumDisplay && !vnumInput.dataset.vnumEscucha) {
+        vnumInput.addEventListener('input', () => {
+            vnumDisplay.textContent = vnumInput.value;
+        });
+        vnumInput.dataset.vnumEscucha = 'true';
+    }
+
+    const nameInput = cardElement.querySelector('.mob-short-desc');
+    const nameDisplay = cardElement.querySelector('.mob-name-display');
+    if (nameInput && nameDisplay && !nameInput.dataset.nombreEscucha) {
+        nameInput.addEventListener('input', () => {
+            nameDisplay.textContent = nameInput.value;
+        });
+        nameInput.dataset.nombreEscucha = 'true';
+    }
+}
+
 export function setupMobilesSection(vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector) {
     const mobContainer = document.getElementById('mobiles-container');
 
-    // Function to attach event listeners to a single mob card
-    const attachMobCardListeners = (cardElement) => {
-        const levelInput = cardElement.querySelector('.mob-level');
-        const hitrollInput = cardElement.querySelector('.mob-hitroll');
-        const hpDiceNumInput = cardElement.querySelector('.mob-hp-dice-num');
-        const hpDiceSidesInput = cardElement.querySelector('.mob-hp-dice-sides');
-        const hpDiceBonusInput = cardElement.querySelector('.mob-hp-dice-bonus');
-        const manaDiceNumInput = cardElement.querySelector('.mob-mana-dice-num');
-        const manaDiceSidesInput = cardElement.querySelector('.mob-mana-dice-sides');
-        const manaDiceBonusInput = cardElement.querySelector('.mob-mana-dice-bonus');
-        const damDiceNumInput = cardElement.querySelector('.mob-dam-dice-num');
-        const damDiceSidesInput = cardElement.querySelector('.mob-dam-dice-sides');
-        const damDiceBonusInput = cardElement.querySelector('.mob-dam-dice-bonus');
-        const acPierceInput = cardElement.querySelector('.mob-ac-pierce');
-        const acBashInput = cardElement.querySelector('.mob-ac-bash');
-        const acSlashInput = cardElement.querySelector('.mob-ac-slash');
-        const acMagicInput = cardElement.querySelector('.mob-ac-magic');
-
-        const updateMobStats = () => {
-            const level = parseInt(levelInput.value);
-            if (isNaN(level)) {
-                hitrollInput.value = '';
-                hpDiceNumInput.value = '';
-                hpDiceSidesInput.value = '';
-                hpDiceBonusInput.value = '';
-                manaDiceNumInput.value = '';
-                manaDiceSidesInput.value = '';
-                manaDiceBonusInput.value = '';
-                damDiceNumInput.value = '';
-                damDiceSidesInput.value = '';
-                damDiceBonusInput.value = '';
-                acPierceInput.value = '';
-                acBashInput.value = '';
-                acSlashInput.value = '';
-                acMagicInput.value = '';
-                return;
-            }
-
-            // Update Hitroll
-            let recommendedHitroll = 0;
-            for (const rec of gameData.hitrollRecommendations) {
-                if (level >= rec.levelStart && level <= rec.levelEnd) {
-                    const levelRatio = (level - rec.levelStart) / (rec.levelEnd - rec.levelStart);
-                    recommendedHitroll = Math.round(rec.hitrollMin + levelRatio * (rec.hitrollMax - rec.hitrollMin));
-                    break;
-                } else if (level < rec.levelStart) {
-                    recommendedHitroll = rec.hitrollMin;
-                    break;
-                } else if (level > gameData.hitrollRecommendations[gameData.hitrollRecommendations.length - 1].levelEnd) {
-                    recommendedHitroll = gameData.hitrollRecommendations[gameData.hitrollRecommendations.length - 1].hitrollMax;
-                    break;
-                }
-            }
-            hitrollInput.value = recommendedHitroll;
-
-            // Update HP, Mana, Armor, Damage
-            let mobStats = null;
-            // Find exact match or closest lower level
-            for (let i = gameData.mobStatsRecommendations.length - 1; i >= 0; i--) {
-                if (level >= gameData.mobStatsRecommendations[i].level) {
-                    mobStats = gameData.mobStatsRecommendations[i];
-                    break;
-                }
-            }
-
-            if (mobStats) {
-                hpDiceNumInput.value = mobStats.hpManaDice.num;
-                hpDiceSidesInput.value = mobStats.hpManaDice.sides;
-                hpDiceBonusInput.value = mobStats.hpManaDice.bonus;
-
-                // Calculate Mana based on formula: 1d10 + 100 * Level
-                manaDiceNumInput.value = 1;
-                manaDiceSidesInput.value = 10;
-                manaDiceBonusInput.value = 100 * level;
-
-                damDiceNumInput.value = mobStats.damageDice.num;
-                damDiceSidesInput.value = mobStats.damageDice.sides;
-                damDiceBonusInput.value = mobStats.damageDice.bonus;
-
-                acPierceInput.value = mobStats.armor;
-                acBashInput.value = mobStats.armor;
-                acSlashInput.value = mobStats.armor;
-
-                // Calculate AC Magic
-                const ac = parseInt(mobStats.armor);
-                if (!isNaN(ac)) {
-                    acMagicInput.value = Math.round(((ac - 10) / 3) + 10);
-                }
-            } else { // If level is below the first entry, use first entry's values
-                const firstStats = gameData.mobStatsRecommendations[0];
-                hpDiceNumInput.value = firstStats.hpManaDice.num;
-                hpDiceSidesInput.value = firstStats.hpManaDice.sides;
-                hpDiceBonusInput.value = firstStats.hpManaDice.bonus;
-
-                manaDiceNumInput.value = firstStats.hpManaDice.num;
-                manaDiceSidesInput.value = firstStats.hpManaDice.sides;
-                manaDiceBonusInput.value = firstStats.hpManaDice.bonus;
-
-                damDiceNumInput.value = firstStats.damageDice.num;
-                damDiceSidesInput.value = firstStats.damageDice.sides;
-                damDiceBonusInput.value = firstStats.damageDice.bonus;
-
-                acPierceInput.value = firstStats.armor;
-                acBashInput.value = firstStats.armor;
-                acSlashInput.value = firstStats.armor;
-
-                const ac = parseInt(firstStats.armor);
-                if (!isNaN(ac)) {
-                    acMagicInput.value = Math.round(((ac - 10) / 3) + 10);
-                }
-            }
-        };
-
-        levelInput.addEventListener('input', updateMobStats);
-        // Initial update if a default level is set
-        updateMobStats();
-    };
-
-    // Call setupDynamicSection and pass the callback for new cards
     setupDynamicSection('add-mob-btn', 'mobiles-container', 'mob-template', '.mob-card', vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector, (cardElement) => {
-        attachMobCardListeners(cardElement);
+        inicializarTarjetaMob(cardElement);
         refrescarOpcionesResets();
     });
 
-    // Attach event listeners for existing cards if they are loaded (e.g., from file)
     mobContainer.querySelectorAll('.mob-card').forEach(card => {
-        attachMobCardListeners(card);
+        inicializarTarjetaMob(card);
     });
 }
 

--- a/js/parser.js
+++ b/js/parser.js
@@ -3,6 +3,7 @@ import { refrescarOpcionesResets } from './resets.js';
 import { poblarSelectsTienda } from './shops.js';
 import { poblarSelectEspecial } from './specials.js';
 import { gameData } from './config.js';
+import { inicializarTarjetaMob } from './mobiles.js';
 
 export function parseAreFile(content) {
     console.log('Parsing .are file...');
@@ -149,8 +150,17 @@ function populateAreaForm(areaData) {
     document.getElementById('area-min-level').value = areaData.minLevel;
     document.getElementById('area-max-level').value = areaData.maxLevel;
     document.getElementById('area-creator').value = areaData.creator;
-    document.getElementById('area-vnum-start').value = areaData.vnumStart;
-    document.getElementById('area-vnum-end').value = areaData.vnumEnd;
+
+    const vnumStartInput = document.getElementById('area-vnum-start');
+    const vnumEndInput = document.getElementById('area-vnum-end');
+
+    vnumStartInput.value = areaData.vnumStart;
+    vnumEndInput.value = areaData.vnumEnd;
+
+    // Actualiza el aviso de rango de VNUMs tras importar un área
+    vnumStartInput.dispatchEvent(new Event('input'));
+    vnumEndInput.dispatchEvent(new Event('input'));
+
     document.getElementById('area-region').value = areaData.region;
 }
 
@@ -257,6 +267,7 @@ function parsearDados(cadena) {
 function populateMobilesSection(mobilesData) {
     const container = document.getElementById('mobiles-container');
     const template = document.getElementById('mob-template');
+    const advertencias = [];
 
     mobilesData.forEach(mob => {
         const newCard = template.content.cloneNode(true);
@@ -283,30 +294,64 @@ function populateMobilesSection(mobilesData) {
             });
         }
 
+        // Función auxiliar para verificar valores de <select>
+        const verificarValor = (selector, valor, nombreCampo, valoresPermitidos = null) => {
+            const select = addedCardElement.querySelector(selector);
+            if (!select) return;
+            select.value = valor;
+            const opciones = valoresPermitidos || Array.from(select.options).map(o => o.value);
+            if (!opciones.includes(valor)) {
+                advertencias.push(`${nombreCampo} desconocido en mob ${mob.vnum}: ${valor}`);
+            }
+        };
+
+        // Función auxiliar para poblar y verificar flags por leyenda
+        const verificarFlags = (leyenda, flags, nombreCampo) => {
+            poblarCheckboxesPorLeyenda(addedCardElement, leyenda, flags);
+            if (!flags || flags === '0') return;
+            let valores = [];
+            const fieldsets = addedCardElement.querySelectorAll('fieldset');
+            for (const fieldset of fieldsets) {
+                const legend = fieldset.querySelector('legend');
+                if (legend && legend.textContent.trim() === leyenda) {
+                    valores = Array.from(fieldset.querySelectorAll('input[type="checkbox"]')).map(cb => cb.value);
+                    break;
+                }
+            }
+            let restante = flags;
+            valores.sort((a, b) => b.length - a.length).forEach(val => {
+                restante = restante.split(val).join('');
+            });
+            if (restante.trim() !== '') {
+                advertencias.push(`${nombreCampo} desconocidos en mob ${mob.vnum}: ${restante}`);
+            }
+        };
+
+        // Asignación de valores básicos
         addedCardElement.querySelector('.mob-vnum').value = mob.vnum;
         addedCardElement.querySelector('.mob-keywords').value = mob.keywords;
         addedCardElement.querySelector('.mob-short-desc').value = mob.shortDesc;
         addedCardElement.querySelector('.mob-long-desc').value = mob.longDesc;
         addedCardElement.querySelector('.mob-look-desc').value = mob.lookDesc;
-        addedCardElement.querySelector('.mob-race').value = mob.race;
+        verificarValor('.mob-race', mob.race, 'Raza', gameData.races);
         addedCardElement.querySelector('.mob-alignment').value = mob.alignment;
         addedCardElement.querySelector('.mob-group').value = mob.group;
         addedCardElement.querySelector('.mob-level').value = mob.level;
         addedCardElement.querySelector('.mob-hitroll').value = mob.hitroll;
-        addedCardElement.querySelector('.mob-sex').value = mob.sex;
+        verificarValor('.mob-sex', mob.sex, 'Sexo');
         addedCardElement.querySelector('.mob-gold').value = mob.gold;
-        addedCardElement.querySelector('.mob-size').value = mob.size;
+        verificarValor('.mob-size', mob.size, 'Tamaño');
         addedCardElement.querySelector('.mob-material').value = mob.material;
 
         // Flags (Act, Affect, Offensive, Imm/Res/Vul, Form, Parts)
-        poblarCheckboxesPorLeyenda(addedCardElement, 'Act Flags', mob.actFlags);
-        poblarCheckboxesPorLeyenda(addedCardElement, 'Afect Flags', mob.affectFlags);
-        poblarCheckboxesPorLeyenda(addedCardElement, 'Ofensivo Flags', mob.offensiveFlags);
-        poblarCheckboxesPorLeyenda(addedCardElement, 'Inmunidades', mob.immFlags);
-        poblarCheckboxesPorLeyenda(addedCardElement, 'Resistencias', mob.resFlags);
-        poblarCheckboxesPorLeyenda(addedCardElement, 'Vulnerabilidades', mob.vulFlags);
-        poblarCheckboxesPorLeyenda(addedCardElement, 'Forma', mob.form);
-        poblarCheckboxesPorLeyenda(addedCardElement, 'Partes', mob.parts);
+        verificarFlags('Act Flags', mob.actFlags, 'Act Flags');
+        verificarFlags('Afect Flags', mob.affectFlags, 'Afect Flags');
+        verificarFlags('Ofensivo Flags', mob.offensiveFlags, 'Ofensivo Flags');
+        verificarFlags('Inmunidades', mob.immFlags, 'Inmunidades');
+        verificarFlags('Resistencias', mob.resFlags, 'Resistencias');
+        verificarFlags('Vulnerabilidades', mob.vulFlags, 'Vulnerabilidades');
+        verificarFlags('Forma', mob.form, 'Forma');
+        verificarFlags('Partes', mob.parts, 'Partes');
 
         // Dados (HP, Mana, Daño)
         addedCardElement.querySelector('.mob-hp-dice-num').value = mob.hpDice.num;
@@ -318,7 +363,7 @@ function populateMobilesSection(mobilesData) {
         addedCardElement.querySelector('.mob-dam-dice-num').value = mob.damageDice.num;
         addedCardElement.querySelector('.mob-dam-dice-sides').value = mob.damageDice.lados;
         addedCardElement.querySelector('.mob-dam-dice-bonus').value = mob.damageDice.bono;
-        addedCardElement.querySelector('.mob-dam-type').value = mob.damageType;
+        verificarValor('.mob-dam-type', mob.damageType, 'Tipo de daño', gameData.damageTypes.map(dt => dt.value));
 
         // Armaduras
         addedCardElement.querySelector('.mob-ac-pierce').value = mob.acPierce;
@@ -327,15 +372,20 @@ function populateMobilesSection(mobilesData) {
         addedCardElement.querySelector('.mob-ac-magic').value = mob.acMagic;
 
         // Posiciones
-        addedCardElement.querySelector('.mob-start-pos').value = mob.startPos;
-        addedCardElement.querySelector('.mob-default-pos').value = mob.defaultPos;
+        verificarValor('.mob-start-pos', mob.startPos, 'Posición inicial');
+        verificarValor('.mob-default-pos', mob.defaultPos, 'Posición por defecto');
 
         // Actualizar encabezado
         addedCardElement.querySelector('.mob-vnum-display').textContent = mob.vnum;
         addedCardElement.querySelector('.mob-name-display').textContent = mob.shortDesc;
 
         container.appendChild(addedCardElement);
+        inicializarTarjetaMob(addedCardElement);
     });
+
+    if (advertencias.length > 0) {
+        alert('Advertencias al importar mobs:\n' + advertencias.join('\n'));
+    }
 }
 
 function parseObjectsSection(sectionContent) {
@@ -1018,8 +1068,17 @@ function clearAllForms() {
     document.getElementById('area-min-level').value = '';
     document.getElementById('area-max-level').value = '';
     document.getElementById('area-creator').value = '';
-    document.getElementById('area-vnum-start').value = '';
-    document.getElementById('area-vnum-end').value = '';
+
+    const vnumStartInput = document.getElementById('area-vnum-start');
+    const vnumEndInput = document.getElementById('area-vnum-end');
+
+    vnumStartInput.value = '';
+    vnumEndInput.value = '';
+
+    // Restablece el aviso de rango de VNUMs al limpiar el formulario
+    vnumStartInput.dispatchEvent(new Event('input'));
+    vnumEndInput.dispatchEvent(new Event('input'));
+
     document.getElementById('area-region').value = '';
 
     // Clear Dynamic Sections

--- a/resumen.md
+++ b/resumen.md
@@ -14,6 +14,8 @@
     *   **Auto-rellenado de HP, Mana, Armaduras y Daño**: Se añadió una tabla de recomendaciones (`mobStatsRecommendations`) a `js/config.js` para los valores de HP, Mana, Armaduras y Daño por nivel. Se modificó `js/mobiles.js` para auto-rellenar estos campos basándose en el nivel del mob. El cálculo de Mana se ajustó para seguir la fórmula `1d10 + 100 * Nivel`, y la Armadura Mágica se calcula con la fórmula `((ac - 10) / 3) + 10`.
     *   **Importación completa de mobs**: Se corrigió el parser para cargar la sección `#MOBILES`, soportando descripciones multilínea, separación de dados y flags en una sola línea.
     *   **Listas de Raza y Tipo de Daño al Importar**: Al cargar un archivo `.are`, los desplegables de raza y tipo de daño se rellenan con `gameData` y se seleccionan los valores correspondientes de cada mob.
+    *   **Reinicialización tras importar**: Los mobs cargados desde archivos recuperan la opción de colapsar y el autoajuste de estadísticas al cambiar el nivel.
+    *   **Advertencias de datos desconocidos**: Durante la importación se revisan todas las listas y flags, avisando cuando cualquier valor (raza, tipo de daño, posiciones, sexo, tamaño o flags) no existe en las opciones de la aplicación.
 *   **Mejoras en la Sección Objects**:
     *   **Campo Material (Datalist)**:
         *   **Funcionalidad**: Se implementó un campo de entrada para "Material" que permite seleccionar de una lista de sugerencias o escribir un valor personalizado. Esto se logró utilizando un elemento `<datalist>` en `index.html` vinculado al campo de entrada.
@@ -76,3 +78,4 @@
 *   **Carga de archivos .are**:
     *   Se corrigió el parser para reconocer solo las secciones principales y respetar los delimitadores internos `#0` y `~`, permitiendo importar áreas completas.
     *   Se ajustó la lectura de la cabecera `#AREA` para separar correctamente el rango de niveles, el creador, los VNUMs y la región, admitiendo variaciones de formato.
+    *   Tras importar un área se actualiza el mensaje de rango de VNUMs, eliminando la advertencia si el rango es válido.


### PR DESCRIPTION
## Resumen
- Se actualizó la validación del rango de VNUM al importar áreas, ocultando la advertencia cuando el rango es válido
- Se restablece el aviso del rango de VNUMs al limpiar el formulario

## Pruebas
- `npm test` (falla: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68bb2f03e838832d8b62307547954915