### PR TITLE
Evitar autonivel de mobs importados

### DIFF
--- a/instrucciones.md
+++ b/instrucciones.md
@@ -310,3 +310,4 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Se ampliaron las advertencias al importar mobs para revisar todas las listas y flags, notificando valores desconocidos en raza, tipo de daño, posiciones, sexo, tamaño y flags.
 - Al importar un área se actualiza el aviso del rango de VNUMs, ocultando la advertencia cuando el rango es válido.
 - Las advertencias al importar mobs muestran ahora VNUM y nombre, y se conservan en la sección ADVERTENCIAS.
+- Se desactivó el autoajuste de estadísticas al importar mobs para preservar sus valores originales.

--- a/js/mobiles.js
+++ b/js/mobiles.js
@@ -2,7 +2,8 @@ import { setupDynamicSection, getFlagString } from './utils.js';
 import { gameData } from './config.js';
 import { refrescarOpcionesResets } from './resets.js';
 
-export function inicializarTarjetaMob(cardElement) {
+// autoAjustar indica si se deben calcular estadísticas al inicializar
+export function inicializarTarjetaMob(cardElement, autoAjustar = true) {
     const levelInput = cardElement.querySelector('.mob-level');
     const hitrollInput = cardElement.querySelector('.mob-hitroll');
     const hpDiceNumInput = cardElement.querySelector('.mob-hp-dice-num');
@@ -111,7 +112,9 @@ export function inicializarTarjetaMob(cardElement) {
 
     if (levelInput) {
         levelInput.addEventListener('input', updateMobStats);
-        updateMobStats();
+        if (autoAjustar) {
+            updateMobStats();
+        }
     }
 
     const header = cardElement.querySelector('.collapsible-header');

--- a/js/parser.js
+++ b/js/parser.js
@@ -395,7 +395,8 @@ function populateMobilesSection(mobilesData) {
         addedCardElement.querySelector('.mob-name-display').textContent = mob.shortDesc;
 
         container.appendChild(addedCardElement);
-        inicializarTarjetaMob(addedCardElement);
+        // No ajusta estadísticas al importar para preservar valores originales
+        inicializarTarjetaMob(addedCardElement, false);
     });
 
     if (advertencias.length > 0) {

--- a/resumen.md
+++ b/resumen.md
@@ -16,6 +16,7 @@
     *   **Listas de Raza y Tipo de Daño al Importar**: Al cargar un archivo `.are`, los desplegables de raza y tipo de daño se rellenan con `gameData` y se seleccionan los valores correspondientes de cada mob.
     *   **Reinicialización tras importar**: Los mobs cargados desde archivos recuperan la opción de colapsar y el autoajuste de estadísticas al cambiar el nivel.
     *   **Advertencias de datos desconocidos**: Durante la importación se revisan todas las listas y flags, avisando cuando cualquier valor (raza, tipo de daño, posiciones, sexo, tamaño o flags) no existe en las opciones de la aplicación.
+    *   **Autonivel desactivado al importar**: Los mobs importados mantienen sus estadísticas originales y solo se ajustan al modificar manualmente el nivel.
 *   **Mejoras en la Sección Objects**:
     *   **Campo Material (Datalist)**:
         *   **Funcionalidad**: Se implementó un campo de entrada para "Material" que permite seleccionar de una lista de sugerencias o escribir un valor personalizado. Esto se logró utilizando un elemento `<datalist>` en `index.html` vinculado al campo de entrada.


### PR DESCRIPTION
## Resumen
- Añadí un parámetro `autoAjustar` para controlar el cálculo inicial de estadísticas en mobs.
- Ajusté el parser para no modificar las estadísticas de los mobs importados.
- Actualicé la documentación para reflejar el comportamiento de importación.

## Pruebas
- `npm test` (falla: Could not read package.json)
- `node --check js/mobiles.js js/parser.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb47fd352c832d93ec7b8da425d913