### PR TITLE
Corrige duplicación de extensión al importar áreas

### DIFF
--- a/instrucciones.md
+++ b/instrucciones.md
@@ -311,3 +311,4 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Al importar un área se actualiza el aviso del rango de VNUMs, ocultando la advertencia cuando el rango es válido.
 - Las advertencias al importar mobs muestran ahora VNUM y nombre, y se conservan en la sección ADVERTENCIAS.
 - Se desactivó el autoajuste de estadísticas al importar mobs para preservar sus valores originales.
+- Se corrigió la importación del nombre de archivo en la sección `#AREA`, eliminando la tilde final y evitando que al guardar se duplique la extensión `.are`.

--- a/js/area.js
+++ b/js/area.js
@@ -37,7 +37,11 @@ export function generateAreaSection() {
     const region = document.getElementById('area-region').value.trim();
 
     let section = '#AREA\n';
-    section += `${filename || 'default'}.are~\n`;
+    let cleanFilename = filename.replace(/~$/, '').trim();
+    if (cleanFilename && !cleanFilename.endsWith('.are')) {
+        cleanFilename += '.are';
+    }
+    section += `${cleanFilename || 'default.are'}~\n`;
     section += `${areaName}~\n`;
     section += `{ ${minLevel || 0} ${maxLevel || 0} } ${creator}~\n`;
     section += `${vnumStart || 0} ${vnumEnd || 0}\n`;

--- a/js/parser.js
+++ b/js/parser.js
@@ -138,7 +138,7 @@ function parseAreaSection(sectionContent) {
     const areaData = {};
 
     // Formato esperado: filename, nombre, linea de niveles + creador + región, vnums
-    areaData.filename = lines[0] ? lines[0].trim() : '';
+    areaData.filename = lines[0] ? lines[0].replace(/~$/, '').trim() : '';
     areaData.name = lines[1] ? lines[1].replace(/~$/, '').trim() : '';
 
     const lineaNivel = lines[2] || '';

--- a/resumen.md
+++ b/resumen.md
@@ -81,3 +81,4 @@
     *   Se ajustó la lectura de la cabecera `#AREA` para separar correctamente el rango de niveles, el creador, los VNUMs y la región, admitiendo variaciones de formato.
     *   Tras importar un área se actualiza el mensaje de rango de VNUMs, eliminando la advertencia si el rango es válido.
     *   Las advertencias de mobs importados incluyen VNUM y nombre y se registran en la sección ADVERTENCIAS.
+    *   Se corrigió el nombre de archivo importado en `#AREA`, quitando la tilde final y evitando que al guardar se duplique la extensión `.are`.


### PR DESCRIPTION
## Resumen
- Limpieza del nombre de archivo en `#AREA` al parsear para evitar `~` residuales
- Generación de `#AREA` ajustada para añadir `.are` solo una vez
- Documentación actualizada sobre el manejo del nombre del área

## Pruebas
- `node --check js/area.js`
- `node --check js/parser.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb49bbf544832da7c509e695266e26