### PR TITLE
Encabezados fijos y colapso global de secciones

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,9 +142,17 @@
                     <h2>
                         #MOBILES
                     </h2>
-                    <button class="add-btn" id="add-mob-btn">
-                        Añadir Mob
-                    </button>
+                    <div class="section-controls">
+                        <button class="add-btn collapse-all-btn">
+                            Contraer Todo
+                        </button>
+                        <button class="add-btn expand-all-btn">
+                            Expandir Todo
+                        </button>
+                        <button class="add-btn" id="add-mob-btn">
+                            Añadir Mob
+                        </button>
+                    </div>
                 </div>
                 <div id="mobiles-container">
                 </div>
@@ -154,9 +162,17 @@
                     <h2>
                         #OBJECTS
                     </h2>
-                    <button class="add-btn" id="add-object-btn">
-                        Añadir Objeto
-                    </button>
+                    <div class="section-controls">
+                        <button class="add-btn collapse-all-btn">
+                            Contraer Todo
+                        </button>
+                        <button class="add-btn expand-all-btn">
+                            Expandir Todo
+                        </button>
+                        <button class="add-btn" id="add-object-btn">
+                            Añadir Objeto
+                        </button>
+                    </div>
                 </div>
                 <div id="objects-container">
                 </div>
@@ -166,9 +182,17 @@
                     <h2>
                         #ROOMS
                     </h2>
-                    <button class="add-btn" id="add-room-btn">
-                        Añadir Habitación
-                    </button>
+                    <div class="section-controls">
+                        <button class="add-btn collapse-all-btn">
+                            Contraer Todo
+                        </button>
+                        <button class="add-btn expand-all-btn">
+                            Expandir Todo
+                        </button>
+                        <button class="add-btn" id="add-room-btn">
+                            Añadir Habitación
+                        </button>
+                    </div>
                 </div>
                 <div id="rooms-container">
                 </div>
@@ -218,9 +242,17 @@
                     <h2>
                         #SET
                     </h2>
-                    <button class="add-btn" id="add-set-btn">
-                        Añadir Set
-                    </button>
+                    <div class="section-controls">
+                        <button class="add-btn collapse-all-btn">
+                            Contraer Todo
+                        </button>
+                        <button class="add-btn expand-all-btn">
+                            Expandir Todo
+                        </button>
+                        <button class="add-btn" id="add-set-btn">
+                            Añadir Set
+                        </button>
+                    </div>
                 </div>
                 <div id="sets-container">
                 </div>
@@ -230,9 +262,17 @@
                     <h2>
                         #SHOPS
                     </h2>
-                    <button class="add-btn" id="add-shop-btn">
-                        Añadir Tienda
-                    </button>
+                    <div class="section-controls">
+                        <button class="add-btn collapse-all-btn">
+                            Contraer Todo
+                        </button>
+                        <button class="add-btn expand-all-btn">
+                            Expandir Todo
+                        </button>
+                        <button class="add-btn" id="add-shop-btn">
+                            Añadir Tienda
+                        </button>
+                    </div>
                 </div>
                 <div id="shops-container">
                 </div>
@@ -242,9 +282,17 @@
                     <h2>
                         #SPECIALS
                     </h2>
-                    <button class="add-btn" id="add-special-btn">
-                        Añadir Especial
-                    </button>
+                    <div class="section-controls">
+                        <button class="add-btn collapse-all-btn">
+                            Contraer Todo
+                        </button>
+                        <button class="add-btn expand-all-btn">
+                            Expandir Todo
+                        </button>
+                        <button class="add-btn" id="add-special-btn">
+                            Añadir Especial
+                        </button>
+                    </div>
                 </div>
                 <div id="specials-container">
                 </div>
@@ -254,9 +302,17 @@
                     <h2>
                         #MOBPROGS
                     </h2>
-                    <button class="add-btn" id="add-mobprog-btn">
-                        Añadir MobProg
-                    </button>
+                    <div class="section-controls">
+                        <button class="add-btn collapse-all-btn">
+                            Contraer Todo
+                        </button>
+                        <button class="add-btn expand-all-btn">
+                            Expandir Todo
+                        </button>
+                        <button class="add-btn" id="add-mobprog-btn">
+                            Añadir MobProg
+                        </button>
+                    </div>
                 </div>
                 <div id="mobprogs-container">
                 </div>
@@ -266,9 +322,17 @@
                     <h2>
                         #OBJPROGS
                     </h2>
-                    <button class="add-btn" id="add-objprog-btn">
-                        Añadir ObjProg
-                    </button>
+                    <div class="section-controls">
+                        <button class="add-btn collapse-all-btn">
+                            Contraer Todo
+                        </button>
+                        <button class="add-btn expand-all-btn">
+                            Expandir Todo
+                        </button>
+                        <button class="add-btn" id="add-objprog-btn">
+                            Añadir ObjProg
+                        </button>
+                    </div>
                 </div>
                 <div id="objprogs-container">
                 </div>
@@ -278,9 +342,17 @@
                     <h2>
                         #ROOMPROGS
                     </h2>
-                    <button class="add-btn" id="add-roomprog-btn">
-                        Añadir RoomProg
-                    </button>
+                    <div class="section-controls">
+                        <button class="add-btn collapse-all-btn">
+                            Contraer Todo
+                        </button>
+                        <button class="add-btn expand-all-btn">
+                            Expandir Todo
+                        </button>
+                        <button class="add-btn" id="add-roomprog-btn">
+                            Añadir RoomProg
+                        </button>
+                    </div>
                 </div>
                 <div id="roomprogs-container">
                 </div>

--- a/instrucciones.md
+++ b/instrucciones.md
@@ -312,3 +312,4 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Las advertencias al importar mobs muestran ahora VNUM y nombre, y se conservan en la sección ADVERTENCIAS.
 - Se desactivó el autoajuste de estadísticas al importar mobs para preservar sus valores originales.
 - Se corrigió la importación del nombre de archivo en la sección `#AREA`, eliminando la tilde final y evitando que al guardar se duplique la extensión `.are`.
+- Se añadieron botones para contraer y expandir todas las tarjetas de cada sección y se fijaron los encabezados para mantener visibles los controles y el botón de añadir al desplazarse.

--- a/resumen.md
+++ b/resumen.md
@@ -1,3 +1,6 @@
+*   **Controles de Sección Fijos**:
+    *   Se añadieron botones para contraer y expandir todas las tarjetas de cada sección.
+    *   Los encabezados de sección permanecen fijos al desplazarse, manteniendo visibles los botones de añadir y los nuevos controles.
 *   **Configuración y Seguridad**:
     *   **Soporte para Múltiples API Keys y Fallback de Modelos**: Se modificó `js/config.js` para permitir un array de `apiKeys`. La función `generateDescriptions` ahora itera a través de estas claves y, para cada una, prueba los modelos en un orden de preferencia (`gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`), conmutando automáticamente si se alcanza una cuota.
     *   **Corrección de Error de Sintaxis y Fallback de API Keys**: Se resolvió un `Uncaught SyntaxError: Unexpected token 'finally'` en `js/utils.js` moviendo el bloque `finally` para que envolviera toda la función `generateDescriptions`. Además, se implementó la lógica de fallback para las API keys y los modelos de IA, permitiendo que la aplicación intente con múltiples configuraciones hasta encontrar una exitosa.

--- a/script.js
+++ b/script.js
@@ -51,6 +51,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
     populateMaterialsDatalist(); // Call the new function here
 
+    // Controles para contraer y expandir todas las tarjetas de una sección
+    document.querySelectorAll('.collapse-all-btn').forEach(boton => {
+        boton.addEventListener('click', () => {
+            const seccion = boton.closest('.content-section');
+            seccion.querySelectorAll('.collapsible-content').forEach(contenido => contenido.classList.add('collapsed'));
+        });
+    });
+
+    document.querySelectorAll('.expand-all-btn').forEach(boton => {
+        boton.addEventListener('click', () => {
+            const seccion = boton.closest('.content-section');
+            seccion.querySelectorAll('.collapsible-content').forEach(contenido => contenido.classList.remove('collapsed'));
+        });
+    });
+
     // Setup main generate button
     document.getElementById('generate-btn').addEventListener('click', generateAreFile);
 

--- a/style.css
+++ b/style.css
@@ -176,6 +176,16 @@ select:focus {
     justify-content: space-between;
     align-items: center;
     margin-bottom: 1.5rem;
+    position: sticky;
+    top: 0;
+    background-color: var(--bg-color);
+    z-index: 5;
+    padding-top: 1rem;
+}
+
+.section-controls {
+    display: flex;
+    gap: 0.5rem;
 }
 
 .add-btn {
@@ -301,7 +311,18 @@ select:focus {
 }
 
 /* Resets */
-#resets-toolbar { background-color: var(--primary-color); padding: 1rem; margin-bottom: 1.5rem; display: flex; flex-wrap: wrap; gap: 1rem; align-items: center; }
+#resets-toolbar {
+    background-color: var(--primary-color);
+    padding: 1rem;
+    margin-bottom: 1.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+    position: sticky;
+    top: 3.5rem;
+    z-index: 4;
+}
 .add-reset-btn { background-color: var(--secondary-color); border: 1px solid var(--border-color); color: var(--text-color); padding: 0.5rem 1rem; cursor: pointer; }
 #resets-list { background-color: var(--primary-color); padding: 1rem; min-height: 100px; }
 .reset-row { display: flex; align-items: center; gap: 1rem; padding: 1rem; border: 1px solid var(--border-color); background-color: var(--input-bg); margin-bottom: 0.5rem; cursor: grab; }


### PR DESCRIPTION
## Resumen
- Se añadieron botones "Contraer Todo" y "Expandir Todo" en las secciones con tarjetas.
- Los encabezados de sección, incluido el botón "Añadir", permanecen visibles al desplazarse.
- Se documentaron los nuevos controles en `instrucciones.md` y `resumen.md`.

## Pruebas
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4aa430dc832da4ed650aaff80831