### PR TITLE
Corregir omisión de objetos en importación de áreas

### DIFF
--- a/instrucciones.md
+++ b/instrucciones.md
@@ -314,3 +314,4 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Se corrigió la importación del nombre de archivo en la sección `#AREA`, eliminando la tilde final y evitando que al guardar se duplique la extensión `.are`.
 - Se añadieron botones para contraer y expandir todas las tarjetas de cada sección y se fijaron los encabezados para mantener visibles los controles y el botón de añadir al desplazarse.
 - Se añadió la importación de la sección `#OBJECTS`, interpretando las líneas de tipo, flags y lugar de vestir en una sola línea, el indicador P/G y las secciones opcionales (S, A, F, E), poblando la interfaz y avisando sobre valores desconocidos.
+- Se corrigió la importación de la sección `#OBJECTS` que omitía objetos consecutivos por un incremento extra del índice.

--- a/js/parser.js
+++ b/js/parser.js
@@ -412,65 +412,64 @@ function parseObjectsSection(sectionContent) {
     while (i < lineas.length) {
         const linea = lineas[i].trim();
         if (linea === '#0') break; // Fin de la sección
-        if (linea.startsWith('#')) {
-            const obj = {};
-            obj.vnum = parseInt(linea.substring(1));
-            i++;
-            obj.keywords = (lineas[i++] || '').replace(/~$/, '').trim();
-            obj.shortDesc = (lineas[i++] || '').replace(/~$/, '').trim();
-            obj.longDesc = (lineas[i++] || '').replace(/~$/, '').trim();
-            obj.material = (lineas[i++] || '').replace(/~$/, '').trim();
+        if (!linea.startsWith('#')) { i++; continue; }
 
-            const tipoLinea = (lineas[i++] || '').trim().split(/\s+/);
-            obj.type = tipoLinea[0] || '';
-            obj.flags = tipoLinea[1] || '0';
-            obj.wearLocation = tipoLinea[2] || '0';
-
-            const vValores = (lineas[i++] || '').trim().split(/\s+/);
-            obj.v0 = vValores[0] || '0';
-            obj.v1 = vValores[1] || '0';
-            obj.v2 = vValores[2] || '0';
-            obj.v3 = vValores[3] || '0';
-            obj.v4 = vValores[4] || '0';
-
-            const stats = (lineas[i++] || '').trim().split(/\s+/);
-            obj.level = parseInt(stats[0]) || 0;
-            obj.weight = parseInt(stats[1]) || 0;
-            obj.price = parseInt(stats[2]) || 0;
-            obj.isDrinkContainer = (stats[3] === 'G');
-
-            obj.set = null;
-            obj.applies = [];
-            obj.affects = [];
-            obj.extraDescriptions = [];
-
-            while (i < lineas.length) {
-                const opt = lineas[i].trim();
-                if (opt === '' || opt.startsWith('#')) break;
-                if (opt === 'S' || opt.startsWith('S ')) {
-                    const partes = opt.split(/\s+/);
-                    obj.set = partes[1] || '';
-                    i++;
-                } else if (opt === 'A' || opt.startsWith('A ')) {
-                    const partes = (opt === 'A' ? lineas[i + 1] : opt.substring(2)).trim().split(/\s+/).map(Number);
-                    obj.applies.push({ location: partes[0], modifier: partes[1] });
-                    i += (opt === 'A') ? 2 : 1;
-                } else if (opt.startsWith('F ')) {
-                    const partes = opt.substring(2).trim().split(/\s+/);
-                    obj.affects.push({ type: partes[0], bits: partes.slice(3).join('') });
-                    i++;
-                } else if (opt === 'E') {
-                    const keywords = (lineas[i + 1] || '').replace(/~$/, '').trim();
-                    const descRes = extraerTextoHastaTilde(lineas, i + 2);
-                    obj.extraDescriptions.push({ keywords, description: descRes.texto.trim() });
-                    i = descRes.indice;
-                } else {
-                    i++;
-                }
-            }
-            objetos.push(obj);
-        }
+        const obj = {};
+        obj.vnum = parseInt(linea.substring(1));
         i++;
+        obj.keywords = (lineas[i++] || '').replace(/~$/, '').trim();
+        obj.shortDesc = (lineas[i++] || '').replace(/~$/, '').trim();
+        obj.longDesc = (lineas[i++] || '').replace(/~$/, '').trim();
+        obj.material = (lineas[i++] || '').replace(/~$/, '').trim();
+
+        const tipoLinea = (lineas[i++] || '').trim().split(/\s+/);
+        obj.type = tipoLinea[0] || '';
+        obj.flags = tipoLinea[1] || '0';
+        obj.wearLocation = tipoLinea[2] || '0';
+
+        const vValores = (lineas[i++] || '').trim().split(/\s+/);
+        obj.v0 = vValores[0] || '0';
+        obj.v1 = vValores[1] || '0';
+        obj.v2 = vValores[2] || '0';
+        obj.v3 = vValores[3] || '0';
+        obj.v4 = vValores[4] || '0';
+
+        const stats = (lineas[i++] || '').trim().split(/\s+/);
+        obj.level = parseInt(stats[0]) || 0;
+        obj.weight = parseInt(stats[1]) || 0;
+        obj.price = parseInt(stats[2]) || 0;
+        obj.isDrinkContainer = (stats[3] === 'G');
+
+        obj.set = null;
+        obj.applies = [];
+        obj.affects = [];
+        obj.extraDescriptions = [];
+
+        while (i < lineas.length) {
+            const opt = lineas[i].trim();
+            if (opt === '' || opt.startsWith('#')) break;
+            if (opt === 'S' || opt.startsWith('S ')) {
+                const partes = opt.split(/\s+/);
+                obj.set = partes[1] || '';
+                i++;
+            } else if (opt === 'A' || opt.startsWith('A ')) {
+                const partes = (opt === 'A' ? lineas[i + 1] : opt.substring(2)).trim().split(/\s+/).map(Number);
+                obj.applies.push({ location: partes[0], modifier: partes[1] });
+                i += (opt === 'A') ? 2 : 1;
+            } else if (opt.startsWith('F ')) {
+                const partes = opt.substring(2).trim().split(/\s+/);
+                obj.affects.push({ type: partes[0], bits: partes.slice(3).join('') });
+                i++;
+            } else if (opt === 'E') {
+                const keywords = (lineas[i + 1] || '').replace(/~$/, '').trim();
+                const descRes = extraerTextoHastaTilde(lineas, i + 2);
+                obj.extraDescriptions.push({ keywords, description: descRes.texto.trim() });
+                i = descRes.indice;
+            } else {
+                i++;
+            }
+        }
+        objetos.push(obj);
     }
     return objetos;
 }

--- a/resumen.md
+++ b/resumen.md
@@ -60,6 +60,7 @@
     *   **Importación de Objetos**:
         *   Se añadió el análisis de la sección `#OBJECTS` al cargar áreas, interpretando los campos de tipo, flags, lugar de vestir, valores V0-V4 y el indicador P/G, además de las secciones opcionales `S`, `A`, `F` y `E`.
         *   Los formularios se rellenan con los datos importados y se muestran advertencias cuando se detectan tipos o flags no reconocidos.
+        *   Se corrigió un incremento extra del índice que provocaba que algunos objetos consecutivos no se importaran.
 *   **Mejoras en la Sección Rooms**:
     *   **Flags de Habitación**: Se corrigió la llamada a `getFlagString` en `js/rooms.js`, permitiendo que los flags seleccionados se escriban correctamente en el archivo `.are`.
     *   **Descripciones Adicionales con IA**: Se agregó un prompt específico para habitaciones y la lógica necesaria para que las descripciones extra utilicen instrucciones diferentes según si pertenecen a un objeto o a una habitación.


### PR DESCRIPTION
## Resumen
- Evité que el parser saltara objetos consecutivos al leer la sección `#OBJECTS`.
- Actualicé la documentación en `instrucciones.md` y `resumen.md`.

## Pruebas
- `node --check js/parser.js`
- `node --check js/objects.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb4e7043c8832dbaa99778f3cecfdb