### PR TITLE
Ampliar advertencias al importar objetos

### DIFF
--- a/instrucciones.md
+++ b/instrucciones.md
@@ -316,4 +316,6 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Se añadió la importación de la sección `#OBJECTS`, interpretando las líneas de tipo, flags y lugar de vestir en una sola línea, el indicador P/G y las secciones opcionales (S, A, F, E), poblando la interfaz y avisando sobre valores desconocidos.
 - Se corrigió la importación de la sección `#OBJECTS` que omitía objetos consecutivos por un incremento extra del índice.
 - Se corrigió la importación de objetos con descripciones extra al ajustar el selector del contenedor correspondiente.
+- Se ampliaron las advertencias al importar objetos comprobando material y valores V0-V4, avisando cuando no existen en las listas.
+- Se añadieron advertencias para el indicador P/G, las ubicaciones de apply y los tipos y bits de affect al importar objetos.
 

--- a/js/parser.js
+++ b/js/parser.js
@@ -438,7 +438,8 @@ function parseObjectsSection(sectionContent) {
         obj.level = parseInt(stats[0]) || 0;
         obj.weight = parseInt(stats[1]) || 0;
         obj.price = parseInt(stats[2]) || 0;
-        obj.isDrinkContainer = (stats[3] === 'G');
+        obj.containerType = stats[3] || 'P';
+        obj.isDrinkContainer = (obj.containerType === 'G');
 
         obj.set = null;
         obj.applies = [];
@@ -526,21 +527,36 @@ function populateObjectsSection(objectsData) {
         addedCardElement.querySelector('.obj-short-desc').value = obj.shortDesc;
         addedCardElement.querySelector('.obj-long-desc').value = obj.longDesc;
         addedCardElement.querySelector('.obj-material').value = obj.material;
+        if (obj.material && !gameData.materials.includes(obj.material)) {
+            advertencias.push(`Material desconocido en objeto ${obj.vnum} (${obj.shortDesc}): ${obj.material}`);
+        }
 
         verificarFlags('Flags', obj.flags, 'Flags');
         verificarFlags('Lugar de Vestir', obj.wearLocation, 'Lugar de Vestir');
 
-        // V0-V4
-        addedCardElement.querySelector('.obj-v0').value = obj.v0;
-        addedCardElement.querySelector('.obj-v1').value = obj.v1;
-        addedCardElement.querySelector('.obj-v2').value = obj.v2;
-        addedCardElement.querySelector('.obj-v3').value = obj.v3;
-        addedCardElement.querySelector('.obj-v4').value = obj.v4;
+        const verificarV = (indice, valor) => {
+            const campo = addedCardElement.querySelector(`.obj-v${indice}`);
+            if (!campo) return;
+            campo.value = valor;
+            if (campo.tagName.toLowerCase() === 'select') {
+                const opciones = Array.from(campo.options).map(o => o.value);
+                if (!opciones.includes(valor)) {
+                    advertencias.push(`V${indice} desconocido en objeto ${obj.vnum} (${obj.shortDesc}): ${valor}`);
+                }
+            }
+        };
+
+        for (let v = 0; v <= 4; v++) {
+            verificarV(v, obj[`v${v}`]);
+        }
 
         addedCardElement.querySelector('.obj-level').value = obj.level;
         addedCardElement.querySelector('.obj-weight').value = obj.weight;
         addedCardElement.querySelector('.obj-price').value = obj.price;
         addedCardElement.querySelector('.obj-is-drink-container').checked = obj.isDrinkContainer;
+        if (obj.containerType !== 'P' && obj.containerType !== 'G') {
+            advertencias.push(`Tipo de contenedor desconocido en objeto ${obj.vnum} (${obj.shortDesc}): ${obj.containerType}`);
+        }
 
         if (obj.set) {
             const setInput = addedCardElement.querySelector('.obj-set-id');
@@ -548,10 +564,10 @@ function populateObjectsSection(objectsData) {
         }
 
         if (obj.applies.length > 0) {
-            populateApplies(addedCardElement, obj.applies);
+            populateApplies(addedCardElement, obj.applies, advertencias, obj);
         }
         if (obj.affects.length > 0) {
-            populateAffects(addedCardElement, obj.affects);
+            populateAffects(addedCardElement, obj.affects, advertencias, obj);
         }
         if (obj.extraDescriptions.length > 0) {
             populateExtraDescriptions(addedCardElement, obj.extraDescriptions);
@@ -569,7 +585,7 @@ function populateObjectsSection(objectsData) {
     }
 }
 
-function populateApplies(containerElement, appliesData) {
+function populateApplies(containerElement, appliesData, advertencias = [], obj = null) {
     const appliesContainer = containerElement.querySelector('.applies-container');
     const applyTemplate = document.getElementById('apply-template');
 
@@ -577,14 +593,19 @@ function populateApplies(containerElement, appliesData) {
         const newApply = applyTemplate.content.cloneNode(true);
         const addedApplyElement = newApply.querySelector('.sub-item-row');
 
-        addedApplyElement.querySelector('.apply-location').value = apply.location;
+        const select = addedApplyElement.querySelector('.apply-location');
+        select.value = apply.location;
+        const opciones = Array.from(select.options).map(o => o.value);
+        if (!opciones.includes(String(apply.location)) && obj) {
+            advertencias.push(`Apply desconocido en objeto ${obj.vnum} (${obj.shortDesc}): ${apply.location}`);
+        }
         addedApplyElement.querySelector('.apply-modifier').value = apply.modifier;
 
         appliesContainer.appendChild(addedApplyElement);
     });
 }
 
-function populateAffects(containerElement, affectsData) {
+function populateAffects(containerElement, affectsData, advertencias = [], obj = null) {
     const affectsContainer = containerElement.querySelector('.affects-container');
     const affectTemplate = document.getElementById('affect-template');
 
@@ -592,9 +613,19 @@ function populateAffects(containerElement, affectsData) {
         const newAffect = affectTemplate.content.cloneNode(true);
         const addedAffectElement = newAffect.querySelector('.sub-item-row');
 
-        addedAffectElement.querySelector('.affect-type').value = affect.type;
+        const typeSelect = addedAffectElement.querySelector('.affect-type');
+        const tipos = Array.from(typeSelect.options).map(o => o.value);
+        typeSelect.value = affect.type;
+        if (!tipos.includes(affect.type) && obj) {
+            advertencias.push(`Tipo de affect desconocido en objeto ${obj.vnum} (${obj.shortDesc}): ${affect.type}`);
+        }
         populateAffectBitSelect(addedAffectElement);
-        addedAffectElement.querySelector('.affect-bits').value = affect.bits;
+        const bitSelect = addedAffectElement.querySelector('.affect-bits');
+        bitSelect.value = affect.bits;
+        const opciones = Array.from(bitSelect.options).map(o => o.value);
+        if (!opciones.includes(affect.bits) && obj) {
+            advertencias.push(`Bits de affect desconocidos en objeto ${obj.vnum} (${obj.shortDesc}): ${affect.bits}`);
+        }
 
         affectsContainer.appendChild(addedAffectElement);
     });

--- a/resumen.md
+++ b/resumen.md
@@ -62,6 +62,8 @@
         *   Los formularios se rellenan con los datos importados y se muestran advertencias cuando se detectan tipos o flags no reconocidos.
         *   Se corrigió un incremento extra del índice que provocaba que algunos objetos consecutivos no se importaran.
         *   Se ajustó el selector del contenedor de descripciones extra para evitar errores al importar objetos con `E`.
+        *   Se ampliaron las advertencias al importar objetos verificando el material y los valores V0-V4 frente a las listas conocidas.
+        *   Se añadieron advertencias para el indicador P/G, las ubicaciones de apply y los tipos y bits de affect.
 *   **Mejoras en la Sección Rooms**:
     *   **Flags de Habitación**: Se corrigió la llamada a `getFlagString` en `js/rooms.js`, permitiendo que los flags seleccionados se escriban correctamente en el archivo `.are`.
     *   **Descripciones Adicionales con IA**: Se agregó un prompt específico para habitaciones y la lógica necesaria para que las descripciones extra utilicen instrucciones diferentes según si pertenecen a un objeto o a una habitación.


### PR DESCRIPTION
## Resumen
- Validar material, tipo, flags, lugar de vestir y valores V0-V4 al importar objetos
- Advertir sobre indicador P/G desconocido y valores inválidos en applies y affects

## Pruebas
- `node --check js/parser.js`
- `node --check js/objects.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb547684c8832d88dcd9ab89bfe239