### PR TITLE
Ampliar advertencias al importar objetos

### DIFF
--- a/instrucciones.md
+++ b/instrucciones.md
@@ -316,4 +316,6 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Se añadió la importación de la sección `#OBJECTS`, interpretando las líneas de tipo, flags y lugar de vestir en una sola línea, el indicador P/G y las secciones opcionales (S, A, F, E), poblando la interfaz y avisando sobre valores desconocidos.
 - Se corrigió la importación de la sección `#OBJECTS` que omitía objetos consecutivos por un incremento extra del índice.
 - Se corrigió la importación de objetos con descripciones extra al ajustar el selector del contenedor correspondiente.
+- Se ampliaron las advertencias al importar objetos comprobando los valores V0-V4, avisando cuando no existen en las listas.
+- Se añadieron advertencias para el indicador P/G, las ubicaciones de apply y los tipos y bits de affect al importar objetos.
 

--- a/resumen.md
+++ b/resumen.md
@@ -62,6 +62,8 @@
         *   Los formularios se rellenan con los datos importados y se muestran advertencias cuando se detectan tipos o flags no reconocidos.
         *   Se corrigió un incremento extra del índice que provocaba que algunos objetos consecutivos no se importaran.
         *   Se ajustó el selector del contenedor de descripciones extra para evitar errores al importar objetos con `E`.
+        *   Se ampliaron las advertencias al importar objetos verificando los valores V0-V4 frente a las listas conocidas.
+        *   Se añadieron advertencias para el indicador P/G, las ubicaciones de apply y los tipos y bits de affect.
 *   **Mejoras en la Sección Rooms**:
     *   **Flags de Habitación**: Se corrigió la llamada a `getFlagString` en `js/rooms.js`, permitiendo que los flags seleccionados se escriban correctamente en el archivo `.are`.
     *   **Descripciones Adicionales con IA**: Se agregó un prompt específico para habitaciones y la lógica necesaria para que las descripciones extra utilicen instrucciones diferentes según si pertenecen a un objeto o a una habitación.


### PR DESCRIPTION
## Resumen
- Validar tipo, flags, lugar de vestir y valores V0-V4 al importar objetos
- Advertir sobre indicador P/G desconocido y valores inválidos en applies y affects
- Omitir advertencias sobre material al importar objetos

## Pruebas
- `node --check js/parser.js`
- `node --check js/objects.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb547684c8832d88dcd9ab89bfe239