### PR TITLE
Permitir valores V0-V4 entre comillas al importar objetos

### DIFF
--- a/instrucciones.md
+++ b/instrucciones.md
@@ -318,4 +318,5 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Se corrigió la importación de objetos con descripciones extra al ajustar el selector del contenedor correspondiente.
 - Se ampliaron las advertencias al importar objetos comprobando los valores V0-V4, avisando cuando no existen en las listas.
 - Se añadieron advertencias para el indicador P/G, las ubicaciones de apply y los tipos y bits de affect al importar objetos.
+- Se ajustó la importación de objetos para aceptar valores V0-V4 entre comillas simples, preservando el texto original.
 

--- a/js/parser.js
+++ b/js/parser.js
@@ -427,7 +427,8 @@ function parseObjectsSection(sectionContent) {
         obj.flags = tipoLinea[1] || '0';
         obj.wearLocation = tipoLinea[2] || '0';
 
-        const vValores = (lineas[i++] || '').trim().split(/\s+/);
+        const vLinea = (lineas[i++] || '').trim();
+        const vValores = vLinea.match(/'[^']*'|\S+/g) || [];
         obj.v0 = vValores[0] || '0';
         obj.v1 = vValores[1] || '0';
         obj.v2 = vValores[2] || '0';
@@ -537,12 +538,27 @@ function populateObjectsSection(objectsData) {
         const verificarV = (indice, valor) => {
             const campo = addedCardElement.querySelector(`.obj-v${indice}`);
             if (!campo) return;
-            campo.value = valor;
             if (campo.tagName.toLowerCase() === 'select') {
                 const opciones = Array.from(campo.options).map(o => o.value);
-                if (!opciones.includes(valor)) {
-                    advertencias.push(`V${indice} desconocido en objeto ${obj.vnum} (${obj.shortDesc}): ${valor}`);
+                const sinComillas = valor.replace(/^'(.*)'$/, '$1');
+                const tieneComillas = valor.startsWith("'") && valor.endsWith("'");
+                if (tieneComillas) {
+                    if (!opciones.includes(sinComillas)) {
+                        advertencias.push(`V${indice} desconocido en objeto ${obj.vnum} (${obj.shortDesc}): ${valor}`);
+                    }
+                    const input = document.createElement('input');
+                    input.type = 'text';
+                    input.className = campo.className;
+                    input.value = valor;
+                    campo.replaceWith(input);
+                } else {
+                    campo.value = valor;
+                    if (!opciones.includes(valor)) {
+                        advertencias.push(`V${indice} desconocido en objeto ${obj.vnum} (${obj.shortDesc}): ${valor}`);
+                    }
                 }
+            } else {
+                campo.value = valor;
             }
         };
 

--- a/resumen.md
+++ b/resumen.md
@@ -64,6 +64,7 @@
         *   Se ajustó el selector del contenedor de descripciones extra para evitar errores al importar objetos con `E`.
         *   Se ampliaron las advertencias al importar objetos verificando los valores V0-V4 frente a las listas conocidas.
         *   Se añadieron advertencias para el indicador P/G, las ubicaciones de apply y los tipos y bits de affect.
+        *   Los valores V0-V4 entre comillas simples se reconocen y conservan, convirtiendo el campo a texto si es necesario.
 *   **Mejoras en la Sección Rooms**:
     *   **Flags de Habitación**: Se corrigió la llamada a `getFlagString` en `js/rooms.js`, permitiendo que los flags seleccionados se escriban correctamente en el archivo `.are`.
     *   **Descripciones Adicionales con IA**: Se agregó un prompt específico para habitaciones y la lógica necesaria para que las descripciones extra utilicen instrucciones diferentes según si pertenecen a un objeto o a una habitación.


### PR DESCRIPTION
## Resumen
- Se adaptó el parser de objetos para leer valores V0-V4 encerrados en comillas simples sin perder el texto original.
- Se convierten a campos de texto los V0-V4 con comillas y se evita generar advertencias si son válidos.
- Se actualizaron las instrucciones y el resumen del proyecto para documentar el nuevo comportamiento.

## Pruebas
- `npm test` *(falla: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68bc4e514dd0832d961754cfd8e0ebb3