### PR TITLE
Evitar advertencias al importar hechizos entre comillas en objetos

### DIFF
--- a/instrucciones.md
+++ b/instrucciones.md
@@ -321,4 +321,5 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Se ajustó la importación de objetos para aceptar valores V0-V4 entre comillas simples, preservando el texto original.
 - Se habilitó en objetos de tipo `weapon` la selección múltiple de flags en V4 mediante checkboxes.
 - La lista de flags de arma para V4 se centralizó en `js/config.js` para facilitar su edición.
+- Se corrigió la verificación de los valores V1-V4 al importar objetos, aceptando nombres de hechizo entre comillas sin generar advertencias.
 

--- a/js/parser.js
+++ b/js/parser.js
@@ -541,16 +541,17 @@ function populateObjectsSection(objectsData) {
             if (campo.tagName.toLowerCase() === 'select') {
                 const opciones = Array.from(campo.options).map(o => o.value);
                 const sinComillas = valor.replace(/^'(.*)'$/, '$1');
-                const tieneComillas = valor.startsWith("'") && valor.endsWith("'");
-                if (tieneComillas) {
-                    if (!opciones.includes(sinComillas)) {
-                        advertencias.push(`V${indice} desconocido en objeto ${obj.vnum} (${obj.shortDesc}): ${valor}`);
-                    }
+                if (opciones.includes(valor)) {
+                    campo.value = valor;
+                } else if (opciones.includes(sinComillas)) {
+                    campo.value = sinComillas;
+                } else if (valor.startsWith("'") && valor.endsWith("'")) {
                     const input = document.createElement('input');
                     input.type = 'text';
                     input.className = campo.className;
                     input.value = valor;
                     campo.replaceWith(input);
+                    advertencias.push(`V${indice} desconocido en objeto ${obj.vnum} (${obj.shortDesc}): ${valor}`);
                 } else {
                     campo.value = valor;
                     if (!opciones.includes(valor)) {

--- a/resumen.md
+++ b/resumen.md
@@ -69,6 +69,7 @@
         *   Se ampliaron las advertencias al importar objetos verificando los valores V0-V4 frente a las listas conocidas.
         *   Se añadieron advertencias para el indicador P/G, las ubicaciones de apply y los tipos y bits de affect.
         *   Los valores V0-V4 entre comillas simples se reconocen y conservan, convirtiendo el campo a texto si es necesario.
+        *   Se evitaron advertencias al importar pergaminos, píldoras, bastones y pociones cuando sus valores V1-V4 contienen hechizos entre comillas.
 *   **Mejoras en la Sección Rooms**:
     *   **Flags de Habitación**: Se corrigió la llamada a `getFlagString` en `js/rooms.js`, permitiendo que los flags seleccionados se escriban correctamente en el archivo `.are`.
     *   **Descripciones Adicionales con IA**: Se agregó un prompt específico para habitaciones y la lógica necesaria para que las descripciones extra utilicen instrucciones diferentes según si pertenecen a un objeto o a una habitación.


### PR DESCRIPTION
## Resumen
- Aceptar valores V1-V4 entre comillas al importar objetos, evitando advertencias para pergaminos, píldoras, bastones y pociones
- Documentar la corrección en instrucciones y resumen del proyecto

## Pruebas
- `npm test` *(falla: no existe package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc56f9e674832d958f8819f3a1a4d2