### PR TITLE
Corrige importación de salidas y extras en habitaciones

### DIFF
--- a/instrucciones.md
+++ b/instrucciones.md
@@ -323,4 +323,5 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - La lista de flags de arma para V4 se centralizó en `js/config.js` para facilitar su edición.
 - Se corrigió la verificación de los valores V1-V4 al importar objetos, aceptando nombres de hechizo entre comillas sin generar advertencias.
 - Se normalizó la comparación de los nombres de hechizo con la lista predefinida para evitar advertencias cuando ya incluyen comillas.
+- Se corrigió la importación de la sección `#ROOMS` para reconocer correctamente las salidas y las descripciones adicionales, permitiendo que las `E` aparezcan antes o después de las salidas.
 

--- a/resumen.md
+++ b/resumen.md
@@ -75,6 +75,7 @@
     *   **Flags de Habitación**: Se corrigió la llamada a `getFlagString` en `js/rooms.js`, permitiendo que los flags seleccionados se escriban correctamente en el archivo `.are`.
     *   **Descripciones Adicionales con IA**: Se agregó un prompt específico para habitaciones y la lógica necesaria para que las descripciones extra utilicen instrucciones diferentes según si pertenecen a un objeto o a una habitación.
     *   **Salidas Diagonales**: El selector de salidas permite elegir direcciones diagonales (noreste, noroeste, sureste, suroeste).
+    *   **Importación de Salidas y Extras**: El parser reconoce ahora correctamente las salidas y las descripciones adicionales, admitiendo que las `E` aparezcan antes o después de las salidas.
 *   **Mejoras en la Sección Resets**:
     *   **Selección Desplegable de VNUMs**: Los campos para mobs, objetos y habitaciones fueron reemplazados por menús desplegables que muestran las entidades ya creadas, reduciendo errores al escribir VNUMs manualmente.
     *   **Actualización Automática de Opciones**: Al añadir o eliminar mobs, objetos o habitaciones, las opciones de los reseteos se refrescan automáticamente para reflejar los cambios.


### PR DESCRIPTION
## Resumen
- Corrige la lectura de salas para manejar descripciones multilínea, salidas y descripciones extra en cualquier orden.
- Actualiza la documentación de instrucciones y resumen con la mejora.

## Pruebas
- `node --check js/parser.js`
- `node - <<'NODE'` (se evalúa `parseRoomsSection` contra `documentos/ankh.are`)

------
https://chatgpt.com/codex/tasks/task_e_68bc6a9eed68832d9f16d81d1259805f