### PR TITLE
Corrigió importación de parámetros en resets

### DIFF
--- a/instrucciones.md
+++ b/instrucciones.md
@@ -329,4 +329,5 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Las advertencias se organizaron en listas separadas para MOBILES, OBJETOS y ROOMS dentro de la sección ADVERTENCIAS.
 - Se corrigió la importación de la sección `#RESETS` mostrando los VNUMs correctos y conservando los comentarios.
 - Se añadió un campo de comentario para cada reset y se generan advertencias cuando los VNUMs referenciados no existen o presentan valores desconocidos.
+- Se corrigió la importación de los resets `E`, `D` y `R`, preservando el lugar de vestir, la dirección, el estado de la puerta y la clase de maze.
 

--- a/js/parser.js
+++ b/js/parser.js
@@ -6,6 +6,24 @@ import { gameData } from './config.js';
 import { inicializarTarjetaMob } from './mobiles.js';
 import { inicializarTarjetaRoom } from './rooms.js';
 
+// Rellena un <select> con las opciones indicadas y un placeholder inicial.
+// Se usa al reconstruir la sección de resets al importar un área.
+function poblarSelectBasico(select, opciones) {
+    const valorPrevio = select.dataset.value || '';
+    select.innerHTML = '';
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = '-- selecciona --';
+    select.appendChild(placeholder);
+    opciones.forEach(opt => {
+        const opcion = document.createElement('option');
+        opcion.value = opt.value;
+        opcion.textContent = opt.label;
+        select.appendChild(opcion);
+    });
+    if (valorPrevio) select.value = valorPrevio;
+}
+
 function limpiarAdvertencias() {
     ['advertencias-mobiles', 'advertencias-objetos', 'advertencias-rooms', 'advertencias-resets'].forEach(id => {
         const lista = document.getElementById(id);
@@ -1074,22 +1092,30 @@ function populateResetsSection(resetsData) {
                 const eInputs = specificTemplate.content.cloneNode(true);
                 eInputs.querySelector('.reset-obj-vnum').dataset.value = reset.vnumObject;
                 eInputs.querySelector('.reset-limit').value = reset.limit;
-                eInputs.querySelector('.reset-wear-location').dataset.value = reset.wearLocation;
+                const wearSelect = eInputs.querySelector('.reset-wear-location');
+                wearSelect.dataset.value = reset.wearLocation;
+                poblarSelectBasico(wearSelect, gameData.resetWearLocations);
                 resetInputsContainer.appendChild(eInputs);
                 break;
             case 'D':
                 specificTemplate = document.getElementById('reset-d-template');
                 const dInputs = specificTemplate.content.cloneNode(true);
                 dInputs.querySelector('.reset-room-vnum').dataset.value = reset.vnumRoom;
-                dInputs.querySelector('.reset-direction').dataset.value = reset.direction;
-                dInputs.querySelector('.reset-state').dataset.value = reset.state;
+                const dirSelect = dInputs.querySelector('.reset-direction');
+                dirSelect.dataset.value = reset.direction;
+                poblarSelectBasico(dirSelect, gameData.resetDirections);
+                const stateSelect = dInputs.querySelector('.reset-state');
+                stateSelect.dataset.value = reset.state;
+                poblarSelectBasico(stateSelect, gameData.resetDoorStates);
                 resetInputsContainer.appendChild(dInputs);
                 break;
             case 'R':
                 specificTemplate = document.getElementById('reset-r-template');
                 const rInputs = specificTemplate.content.cloneNode(true);
                 rInputs.querySelector('.reset-room-vnum').dataset.value = reset.vnumRoom;
-                rInputs.querySelector('.reset-maze-class').dataset.value = reset.mazeClass;
+                const mazeSelect = rInputs.querySelector('.reset-maze-class');
+                mazeSelect.dataset.value = reset.mazeClass;
+                poblarSelectBasico(mazeSelect, gameData.resetMazeClasses);
                 resetInputsContainer.appendChild(rInputs);
                 break;
             default:

--- a/resumen.md
+++ b/resumen.md
@@ -86,6 +86,7 @@
     *   **Clase de Maze Ampliada**: Se añadió la clase `10` para laberintos que también consideran las salidas diagonales.
     *   **Importación de Comentarios**: Los resets importados conservan sus comentarios y muestran correctamente los VNUMs.
     *   **Campo de Comentario y Advertencias**: Cada reset cuenta con un campo para comentarios y se advierte cuando los VNUMs referenciados no existen o contienen valores desconocidos.
+    *   **Importación completa de parámetros**: Los resets `E`, `D` y `R` ahora conservan el lugar de vestir, la dirección, el estado de la puerta y la clase de maze al cargar un área.
 *   **Mejoras en la Sección Shops**:
     *   **Listas Desplegables Centralizadas**: Los tipos de objetos que compra la tienda, los porcentajes de compra/venta y las horas de apertura/cierre se seleccionan ahora desde desplegables, alimentados por las nuevas listas `shopObjectTypes`, `shopProfitOptions` y `shopHours` en `js/config.js`.
     *   **Comentarios de Tienda**: Cada tienda puede incluir un comentario opcional; si se especifica, se añade tras un `*` en la línea generada.


### PR DESCRIPTION
## Resumen
- Añadida función auxiliar para poblar selects al importar reseteos
- Resets E, D y R conservan lugar de vestir, dirección, estado de puerta y clase de maze
- Documentación actualizada con el nuevo comportamiento

## Pruebas
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc78669d8c832dad114d7573748f3f