### PR TITLE
Corrige importación de objetos con descripciones largas

### DIFF
--- a/instrucciones.md
+++ b/instrucciones.md
@@ -330,4 +330,5 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Se corrigió la importación de la sección `#RESETS` mostrando los VNUMs correctos y conservando los comentarios.
 - Se añadió un campo de comentario para cada reset y se generan advertencias cuando los VNUMs referenciados no existen o presentan valores desconocidos.
 - Se corrigió la importación de los resets `E`, `D` y `R`, preservando el lugar de vestir, la dirección, el estado de la puerta y la clase de maze.
+- Se corrigió la importación de objetos con descripciones largas en varias líneas para evitar que se omitan.
 

--- a/js/parser.js
+++ b/js/parser.js
@@ -444,7 +444,15 @@ function parseObjectsSection(sectionContent) {
         i++;
         obj.keywords = (lineas[i++] || '').replace(/~$/, '').trim();
         obj.shortDesc = (lineas[i++] || '').replace(/~$/, '').trim();
-        obj.longDesc = (lineas[i++] || '').replace(/~$/, '').trim();
+        // La descripción larga puede ocupar varias líneas hasta encontrar una que termine en "~"
+        const descLarga = [];
+        while (i < lineas.length) {
+            const lineaDesc = lineas[i];
+            descLarga.push(lineaDesc.replace(/~$/, ''));
+            i++;
+            if (lineaDesc.trim().endsWith('~')) break;
+        }
+        obj.longDesc = descLarga.join('\n').trim();
         obj.material = (lineas[i++] || '').replace(/~$/, '').trim();
 
         const tipoLinea = (lineas[i++] || '').trim().split(/\s+/);

--- a/resumen.md
+++ b/resumen.md
@@ -71,6 +71,7 @@
         *   Los valores V0-V4 entre comillas simples se reconocen y conservan, convirtiendo el campo a texto si es necesario.
         *   Se evitaron advertencias al importar pergaminos, píldoras, bastones y pociones cuando sus valores V1-V4 contienen hechizos entre comillas.
         *   Se normalizó la comparación de estos hechizos con la lista predefinida para respetar las comillas existentes.
+        *   Se corrigió la importación de objetos cuya descripción larga ocupaba varias líneas, garantizando que no se omitan.
 *   **Mejoras en la Sección Rooms**:
     *   **Flags de Habitación**: Se corrigió la llamada a `getFlagString` en `js/rooms.js`, permitiendo que los flags seleccionados se escriban correctamente en el archivo `.are`.
     *   **Descripciones Adicionales con IA**: Se agregó un prompt específico para habitaciones y la lógica necesaria para que las descripciones extra utilicen instrucciones diferentes según si pertenecen a un objeto o a una habitación.


### PR DESCRIPTION
## Resumen
- Acepta descripciones largas en múltiples líneas al importar objetos.
- Documenta la corrección en instrucciones y resumen del proyecto.

## Pruebas
- `node - <<'NODE' ...` (parseo de objeto de prueba)
- `npm test` *(falla: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7b961f4c832d8e4066acd4a66a55