### PR TITLE
Restaurar colapsado individual en tiendas

### DIFF
--- a/instrucciones.md
+++ b/instrucciones.md
@@ -334,4 +334,5 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Se restauró la posibilidad de contraer y expandir individualmente las tarjetas de objetos importados incluso después de usar el botón "Contraer Todo".
 - Se corrigió la importación y generación de la sección `#SET`, reconociendo múltiples tiers y leyendo correctamente los affects.
 - Se añadió la inicialización de tarjetas de sets para mantener el colapsado individual incluso tras usar "Contraer Todo".
+- Se corrigió la sección `#SHOPS` para permitir contraer y expandir cada tarjeta desde su encabezado, incluso después de usar "Contraer Todo".
 

--- a/js/parser.js
+++ b/js/parser.js
@@ -1,6 +1,6 @@
 import { populateAffectBitSelect, populateObjectTypeSelect, updateObjectValuesUI, inicializarTarjetaObjeto } from './objects.js';
 import { refrescarOpcionesResets } from './resets.js';
-import { poblarSelectsTienda } from './shops.js';
+import { poblarSelectsTienda, inicializarTarjetaShop } from './shops.js';
 import { poblarSelectEspecial } from './specials.js';
 import { gameData } from './config.js';
 import { inicializarTarjetaMob } from './mobiles.js';
@@ -1301,6 +1301,7 @@ function populateShopsSection(shopsData) {
         card.querySelector('.shop-vnum-display').textContent = shop.vnumSeller;
 
         container.appendChild(fragment);
+        inicializarTarjetaShop(container.lastElementChild);
     });
 }
 

--- a/js/shops.js
+++ b/js/shops.js
@@ -41,8 +41,41 @@ export function poblarSelectsTienda(card) {
     });
 }
 
+export function inicializarTarjetaShop(cardElement) {
+    const header = cardElement.querySelector('.collapsible-header');
+    const content = cardElement.querySelector('.collapsible-content');
+    if (header && content && !header.dataset.colapsado) {
+        header.addEventListener('click', () => {
+            content.classList.toggle('collapsed');
+        });
+        header.dataset.colapsado = 'true';
+    }
+
+    const vnumInput = cardElement.querySelector('.shop-vnum');
+    const vnumDisplay = cardElement.querySelector('.shop-vnum-display');
+    if (vnumInput && vnumDisplay && !vnumInput.dataset.vnumEscucha) {
+        vnumInput.addEventListener('input', () => {
+            vnumDisplay.textContent = vnumInput.value;
+        });
+        vnumInput.dataset.vnumEscucha = 'true';
+    }
+
+    const commentInput = cardElement.querySelector('.shop-comment');
+    const commentDisplay = cardElement.querySelector('.shop-comment-display');
+    if (commentInput && commentDisplay && !commentInput.dataset.nombreEscucha) {
+        commentInput.addEventListener('input', () => {
+            commentDisplay.textContent = commentInput.value;
+        });
+        commentInput.dataset.nombreEscucha = 'true';
+        commentInput.dispatchEvent(new Event('input'));
+    }
+}
+
 export function setupShopsSection(vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector) {
-    setupDynamicSection('add-shop-btn', 'shops-container', 'shop-template', '.shop-card', vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector, poblarSelectsTienda);
+    setupDynamicSection('add-shop-btn', 'shops-container', 'shop-template', '.shop-card', vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector, (card) => {
+        poblarSelectsTienda(card);
+        inicializarTarjetaShop(card);
+    });
 
     const container = document.getElementById('shops-container');
     container.addEventListener('click', (e) => {

--- a/resumen.md
+++ b/resumen.md
@@ -98,6 +98,7 @@
     *   **Comentarios de Tienda**: Cada tienda puede incluir un comentario opcional; si se especifica, se añade tras un `*` en la línea generada.
     *   **Encabezado con comentario**: El comentario de cada tienda se refleja en el título de la tarjeta para reconocerla cuando está contraída.
     *   **Parser y Generación Corregidos**: Se actualizó el formato de lectura y escritura para que cada tienda se procese en una sola línea conforme a la documentación.
+    *   **Colapsado Individual**: Las tarjetas de tiendas pueden contraerse y expandirse desde su encabezado incluso después de usar "Contraer Todo".
 *   **Mejoras en la Sección Specials**:
     *   **Desplegable de Especiales con Tooltips**: El tipo de especial ahora se elige desde un `<select>` poblado dinámicamente con `js/config.js`, mostrando un tooltip explicativo para cada opción.
     *   **Lista Centralizada de Especiales**: Se añadió `gameData.specials` con todos los nombres y descripciones, eliminando el `<datalist>` embebido en `index.html`.


### PR DESCRIPTION
## Resumen
- Se añadió `inicializarTarjetaShop` para vincular encabezados y actualizar vnum y comentario de cada tienda.
- Se ajustó el parser para inicializar las tiendas importadas y permitir su colapsado individual aun tras "Contraer Todo".
- Se actualizaron `instrucciones.md` y `resumen.md` con la nueva funcionalidad.

## Pruebas
- `npm test` *(falla: no se encontró package.json)*
- `node --check js/shops.js js/parser.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc91886ff4832dbc700c9ba60be4fe