### PR TITLE
Propietarios desplegables en progs y disparadores más amplios

### DIFF
--- a/index.html
+++ b/index.html
@@ -1486,6 +1486,12 @@
                         </div>
                     </fieldset>
                 </div>
+                <div class="form-group full-width">
+                    <label>
+                        Disparadores:
+                    </label>
+                    <textarea class="mob-triggers" placeholder="act 3001 se sienta" rows="2"></textarea>
+                </div>
             </div>
         </div>
     </template>
@@ -1938,6 +1944,12 @@
                         Añadir Extra
                     </button>
                 </fieldset>
+                <div class="form-group full-width">
+                    <label>
+                        Disparadores:
+                    </label>
+                    <textarea class="obj-triggers" placeholder="act 3001 se sienta" rows="2"></textarea>
+                </div>
             </div>
         </div>
     </template>
@@ -2155,6 +2167,12 @@
                         Añadir Extra
                     </button>
                 </fieldset>
+                <div class="form-group full-width">
+                    <label>
+                        Disparadores:
+                    </label>
+                    <textarea class="room-triggers" placeholder="act 3001 se sienta" rows="2"></textarea>
+                </div>
             </div>
         </div>
     </template>
@@ -2311,6 +2329,8 @@
                     Prog | Vnum:
                     <span class="prog-vnum-display">
                     </span>
+                    | Propietarios:
+                    <select class="prog-owner-display"></select>
                 </h4>
             </div>
             <div class="collapsible-content">

--- a/instrucciones.md
+++ b/instrucciones.md
@@ -336,4 +336,9 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Se añadió la inicialización de tarjetas de sets para mantener el colapsado individual incluso tras usar "Contraer Todo".
 - Se corrigió la sección `#SHOPS` para permitir contraer y expandir cada tarjeta desde su encabezado, incluso después de usar "Contraer Todo".
 - Se corrigió la sección `#SPECIALS` permitiendo contraer y expandir cada tarjeta desde su encabezado incluso tras usar "Contraer Todo" y se ajustó la importación para leer líneas `M vnum nombre * comentario`.
+- Se añadieron campos de **Disparadores** a mobs, objetos y habitaciones, permitiendo definir las líneas `M/O/R` asociadas a los programas y generándolas en el archivo `.are`.
+- Se detecta y muestra en las secciones `#MOBPROGS`, `#OBJPROGS` y `#ROOMPROGS` a qué entidad pertenece cada prog dentro del área.
+- Las tarjetas de progs pueden contraerse y expandirse individualmente incluso después de usar "Contraer Todo".
+- Se amplió el campo de disparadores de los mobs para que ocupe todo el ancho de su tarjeta.
+- Los progs listan en un desplegable todos los propietarios del tipo correspondiente, evitando mostrar mobs en `#OBJPROGS` y `#ROOMPROGS`.
 

--- a/js/mobiles.js
+++ b/js/mobiles.js
@@ -1,6 +1,7 @@
 import { setupDynamicSection, getFlagString } from './utils.js';
 import { gameData } from './config.js';
 import { refrescarOpcionesResets } from './resets.js';
+import { actualizarPropietariosProgs } from './progs.js';
 
 // autoAjustar indica si se deben calcular estadísticas al inicializar
 export function inicializarTarjetaMob(cardElement, autoAjustar = true) {
@@ -143,6 +144,12 @@ export function inicializarTarjetaMob(cardElement, autoAjustar = true) {
         });
         nameInput.dataset.nombreEscucha = 'true';
     }
+
+    const triggersInput = cardElement.querySelector('.mob-triggers');
+    if (triggersInput && !triggersInput.dataset.trigEscucha) {
+        triggersInput.addEventListener('input', actualizarPropietariosProgs);
+        triggersInput.dataset.trigEscucha = 'true';
+    }
 }
 
 export function setupMobilesSection(vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector) {
@@ -155,6 +162,12 @@ export function setupMobilesSection(vnumRangeCheckFunction, vnumSelector, vnumDi
 
     mobContainer.querySelectorAll('.mob-card').forEach(card => {
         inicializarTarjetaMob(card);
+    });
+
+    mobContainer.addEventListener('click', e => {
+        if (e.target.classList.contains('remove-btn')) {
+            actualizarPropietariosProgs();
+        }
     });
 }
 
@@ -200,6 +213,13 @@ export function generateMobilesSection() {
         const formFlags = getFlagString(mob, 'Forma');
         const partFlags = getFlagString(mob, 'Partes');
         section += `${formFlags} ${partFlags} ${mob.querySelector('.mob-size').value} ${mob.querySelector('.mob-material').value}\n`;
+
+        const triggersText = mob.querySelector('.mob-triggers').value.trim();
+        if (triggersText) {
+            triggersText.split('\n').forEach(linea => {
+                if (linea.trim() !== '') section += `M ${linea.trim()}~\n`;
+            });
+        }
     });
     section += '#0\n\n';
     return section;

--- a/js/objects.js
+++ b/js/objects.js
@@ -1,6 +1,7 @@
 import { setupDynamicSection, getFlagString } from './utils.js';
 import { gameData } from './config.js';
 import { refrescarOpcionesResets } from './resets.js';
+import { actualizarPropietariosProgs } from './progs.js';
 
 export function updateObjectValuesUI(objectCard) {
     const type = objectCard.querySelector('.obj-type').value;
@@ -172,6 +173,12 @@ export function inicializarTarjetaObjeto(cardElement) {
         nameInput.dataset.nombreEscucha = 'true';
         nameInput.dispatchEvent(new Event('input'));
     }
+
+    const triggersInput = cardElement.querySelector('.obj-triggers');
+    if (triggersInput && !triggersInput.dataset.trigEscucha) {
+        triggersInput.addEventListener('input', actualizarPropietariosProgs);
+        triggersInput.dataset.trigEscucha = 'true';
+    }
 }
 
 export function setupObjectsSection(vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector) {
@@ -193,7 +200,10 @@ export function setupObjectsSection(vnumRangeCheckFunction, vnumSelector, vnumDi
 
     container.addEventListener('click', (e) => {
         const target = e.target;
-        if (target.classList.contains('remove-btn')) target.closest('.object-card').remove();
+        if (target.classList.contains('remove-btn')) {
+            target.closest('.object-card').remove();
+            actualizarPropietariosProgs();
+        }
         else if (target.classList.contains('add-apply-btn')) target.previousElementSibling.appendChild(document.getElementById('apply-template').content.cloneNode(true));
         else if (target.classList.contains('add-affect-btn')) {
             const container = target.previousElementSibling;
@@ -266,6 +276,13 @@ export function generateObjectsSection() {
             const desc = row.querySelector('.extra-desc').value;
             if (keyword && desc) section += `E\n${keyword}~\n${desc}~\n`;
         });
+
+        const triggersText = obj.querySelector('.obj-triggers').value.trim();
+        if (triggersText) {
+            triggersText.split('\n').forEach(linea => {
+                if (linea.trim() !== '') section += `O ${linea.trim()}~\n`;
+            });
+        }
 
         section += '\n';
     });

--- a/js/progs.js
+++ b/js/progs.js
@@ -1,8 +1,96 @@
 import { setupDynamicSection } from './utils.js';
 
+export function inicializarTarjetaProg(cardElement) {
+    const header = cardElement.querySelector('.collapsible-header');
+    const content = cardElement.querySelector('.collapsible-content');
+    if (header && content && !header.dataset.colapsado) {
+        header.addEventListener('click', () => {
+            content.classList.toggle('collapsed');
+        });
+        header.dataset.colapsado = 'true';
+    }
+
+    const vnumInput = cardElement.querySelector('.prog-vnum');
+    const vnumDisplay = cardElement.querySelector('.prog-vnum-display');
+    if (vnumInput && vnumDisplay && !vnumInput.dataset.vnumEscucha) {
+        vnumInput.addEventListener('input', () => {
+            vnumDisplay.textContent = vnumInput.value;
+            actualizarPropietariosProgs();
+        });
+        vnumInput.dataset.vnumEscucha = 'true';
+    }
+}
+
+export function actualizarPropietariosProgs() {
+    const progCards = document.querySelectorAll('.prog-card');
+    progCards.forEach(card => {
+        const vnum = parseInt(card.querySelector('.prog-vnum').value);
+        const owners = [];
+        if (vnum) {
+            if (card.closest('#mobprogs-container')) {
+                document.querySelectorAll('#mobiles-container .mob-card').forEach(m => {
+                    const lineas = m.querySelector('.mob-triggers')?.value.split('\n') || [];
+                    if (lineas.some(l => parseInt(l.trim().split(/\s+/)[1]) === vnum)) {
+                        const v = m.querySelector('.mob-vnum').value;
+                        const nombre = m.querySelector('.mob-name-display').textContent;
+                        owners.push(`Mob ${v} ${nombre}`);
+                    }
+                });
+            } else if (card.closest('#objprogs-container')) {
+                document.querySelectorAll('#objects-container .object-card').forEach(o => {
+                    const lineas = o.querySelector('.obj-triggers')?.value.split('\n') || [];
+                    if (lineas.some(l => parseInt(l.trim().split(/\s+/)[1]) === vnum)) {
+                        const v = o.querySelector('.obj-vnum').value;
+                        const nombre = o.querySelector('.obj-name-display').textContent;
+                        owners.push(`Objeto ${v} ${nombre}`);
+                    }
+                });
+            } else if (card.closest('#roomprogs-container')) {
+                document.querySelectorAll('#rooms-container .room-card').forEach(r => {
+                    const lineas = r.querySelector('.room-triggers')?.value.split('\n') || [];
+                    if (lineas.some(l => parseInt(l.trim().split(/\s+/)[1]) === vnum)) {
+                        const v = r.querySelector('.room-vnum').value;
+                        const nombre = r.querySelector('.room-name-display').textContent;
+                        owners.push(`Habitación ${v} ${nombre}`);
+                    }
+                });
+            }
+        }
+        const ownerSelect = card.querySelector('.prog-owner-display');
+        if (ownerSelect) {
+            ownerSelect.innerHTML = '';
+            if (owners.length === 0) {
+                const opt = document.createElement('option');
+                opt.textContent = 'Sin propietarios';
+                ownerSelect.appendChild(opt);
+            } else {
+                owners.forEach(t => {
+                    const opt = document.createElement('option');
+                    opt.textContent = t;
+                    ownerSelect.appendChild(opt);
+                });
+            }
+        }
+    });
+}
+
 export function setupProgsSection(type, vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector) {
     const buttonType = type.replace('s', '');
-    setupDynamicSection(`add-${buttonType}-btn`, `${type}-container`, 'prog-template', '.prog-card', vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector);
+    setupDynamicSection(`add-${buttonType}-btn`, `${type}-container`, 'prog-template', '.prog-card', vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector, (card) => {
+        inicializarTarjetaProg(card);
+        actualizarPropietariosProgs();
+    });
+
+    const container = document.getElementById(`${type}-container`);
+    container.querySelectorAll('.prog-card').forEach(card => {
+        inicializarTarjetaProg(card);
+    });
+    container.addEventListener('click', e => {
+        if (e.target.classList.contains('remove-btn')) {
+            actualizarPropietariosProgs();
+        }
+    });
+    actualizarPropietariosProgs();
 }
 
 export function generateProgsSection(containerId, sectionName) {

--- a/js/rooms.js
+++ b/js/rooms.js
@@ -1,5 +1,6 @@
 import { setupDynamicSection, getFlagString } from './utils.js';
 import { refrescarOpcionesResets } from './resets.js';
+import { actualizarPropietariosProgs } from './progs.js';
 
 export function inicializarTarjetaRoom(cardElement) {
     const header = cardElement.querySelector('.collapsible-header');
@@ -29,6 +30,12 @@ export function inicializarTarjetaRoom(cardElement) {
         nameInput.dataset.nombreEscucha = 'true';
         nameInput.dispatchEvent(new Event('input'));
     }
+
+    const triggersInput = cardElement.querySelector('.room-triggers');
+    if (triggersInput && !triggersInput.dataset.trigEscucha) {
+        triggersInput.addEventListener('input', actualizarPropietariosProgs);
+        triggersInput.dataset.trigEscucha = 'true';
+    }
 }
 
 export function setupRoomsSection(vnumRangeCheckFunction, vnumSelector, vnumDisplaySelector, nameInputSelector, nameDisplaySelector) {
@@ -40,7 +47,10 @@ export function setupRoomsSection(vnumRangeCheckFunction, vnumSelector, vnumDisp
     const container = document.getElementById('rooms-container');
     container.addEventListener('click', (e) => {
         const target = e.target;
-        if (target.classList.contains('remove-btn')) target.closest('.room-card').remove();
+        if (target.classList.contains('remove-btn')) {
+            target.closest('.room-card').remove();
+            actualizarPropietariosProgs();
+        }
         else if (target.classList.contains('add-exit-btn')) target.previousElementSibling.appendChild(document.getElementById('exit-template').content.cloneNode(true));
         else if (target.classList.contains('add-room-extra-btn')) target.previousElementSibling.appendChild(document.getElementById('extra-desc-template').content.cloneNode(true));
         else if (target.classList.contains('remove-sub-btn')) target.closest('.sub-item-row, .sub-item-row-grid').remove();
@@ -81,6 +91,13 @@ export function generateRoomsSection() {
 
         const clan = room.querySelector('.room-clan').value;
         if (clan) section += `C ${clan}~\n`;
+
+        const triggersText = room.querySelector('.room-triggers').value.trim();
+        if (triggersText) {
+            triggersText.split('\n').forEach(linea => {
+                if (linea.trim() !== '') section += `R ${linea.trim()}~\n`;
+            });
+        }
 
         section += 'S\n';
     });

--- a/resumen.md
+++ b/resumen.md
@@ -107,6 +107,9 @@
 
 *   **Progs**:
     *   Se eliminó la integración con Blockly y se volvió al editor de texto para MOBPROGS, OBJPROGS y ROOMPROGS.
+    *   Mobs, objetos y habitaciones incluyen un campo de disparadores para enlazar `M/O/R` con los programas.
+    *   El campo de disparadores de los mobs se amplió para ocupar todo el ancho.
+    *   Cada prog muestra en un desplegable todos los propietarios de su tipo dentro del área y las tarjetas pueden contraerse o expandirse individualmente incluso tras usar "Contraer Todo".
 *   **Carga de archivos .are**:
     *   Se corrigió el parser para reconocer solo las secciones principales y respetar los delimitadores internos `#0` y `~`, permitiendo importar áreas completas.
     *   Se ajustó la lectura de la cabecera `#AREA` para separar correctamente el rango de niveles, el creador, los VNUMs y la región, admitiendo variaciones de formato.

--- a/style.css
+++ b/style.css
@@ -160,6 +160,13 @@ select:focus {
     border-color: var(--header-color);
 }
 
+.mob-triggers,
+.obj-triggers,
+.room-triggers {
+    width: 100%;
+    box-sizing: border-box;
+}
+
 .form-inline {
     flex-direction: row;
     align-items: center;


### PR DESCRIPTION
## Resumen
- El campo de disparadores de los mobs ahora ocupa todo el ancho de la tarjeta
- Cada prog muestra en un desplegable todos los propietarios del tipo correspondiente

## Pruebas
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc96d54cac832db13e2755f596713c