### PR TITLE
Agregar ventana de chat con IA experta

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8" />
+    <title>Chat de Ayuda</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+        body { padding: 1rem; }
+        #registro-chat { height: 80vh; overflow-y: auto; border: 1px solid var(--border-color); padding: 0.5rem; margin-bottom: 0.5rem; }
+        #entrada-chat { display: flex; }
+        #entrada-chat input { flex: 1; margin-right: 0.5rem; }
+    </style>
+</head>
+<body>
+    <h2>Asistente de la aplicación</h2>
+    <div id="registro-chat"></div>
+    <div id="entrada-chat">
+        <input id="mensaje-usuario" type="text" placeholder="Escribe tu pregunta..." />
+        <button id="enviar-mensaje">Enviar</button>
+    </div>
+    <script type="module" src="js/chat.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -2724,6 +2724,9 @@
     </template>
     <datalist id="materials-list">
     </datalist>
+    <button id="btn-chat-ia" class="boton-chat-ia" title="Asistente de la aplicación">
+        IA
+    </button>
 </body>
 
 </html>

--- a/instrucciones.md
+++ b/instrucciones.md
@@ -343,5 +343,6 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Los progs listan en un desplegable todos los propietarios del tipo correspondiente, evitando mostrar mobs en `#OBJPROGS` y `#ROOMPROGS`.
 - Los encabezados de todas las secciones indican ahora la cantidad de elementos que contienen (por ejemplo `#MOBILES - 3`) y el parser reconoce estos sufijos numéricos.
 - Se reemplazó la sección **RESUMEN** por listas desplegables que enumeran los elementos de cada apartado, eliminando las estadísticas.
+- Se añadió un botón flotante que abre una ventana de chat con la IA. Esta IA responde únicamente dudas sobre la aplicación utilizando la documentación del directorio `documentos/`.
 
 

--- a/js/chat.js
+++ b/js/chat.js
@@ -1,0 +1,80 @@
+import { gameData } from './config.js';
+
+// Contenedor de la documentación cargada desde documentos/*.md
+let textoDocumentacion = '';
+// Historial simple de mensajes para contextualizar a la IA
+const historial = [];
+
+async function cargarDocumentacion() {
+    const textos = await Promise.all(
+        gameData.archivosDocumentacion.map(async nombre => {
+            try {
+                const respuesta = await fetch(`documentos/${encodeURIComponent(nombre)}`);
+                return respuesta.ok ? await respuesta.text() : '';
+            } catch (e) {
+                return '';
+            }
+        })
+    );
+    textoDocumentacion = textos.join('\n');
+}
+
+function agregarMensaje(origen, mensaje) {
+    const registro = document.getElementById('registro-chat');
+    const p = document.createElement('p');
+    p.textContent = `${origen}: ${mensaje}`;
+    registro.appendChild(p);
+    registro.scrollTop = registro.scrollHeight;
+}
+
+async function enviarMensaje() {
+    const entrada = document.getElementById('mensaje-usuario');
+    const texto = entrada.value.trim();
+    if (!texto) return;
+    agregarMensaje('Usuario', texto);
+    historial.push({ rol: 'usuario', contenido: texto });
+    entrada.value = '';
+    const respuesta = await consultarIA(texto);
+    agregarMensaje('IA', respuesta);
+    historial.push({ rol: 'ia', contenido: respuesta });
+}
+
+async function consultarIA(textoUsuario) {
+    const instrucciones = `Eres una IA experta en la aplicación web para crear áreas del MUD Petria. Solo respondes preguntas sobre la aplicación y documentos relacionados. Si la pregunta no se relaciona, responde: "Lo siento, solo puedo ayudar con la aplicación." Usa la siguiente documentación para tus respuestas:\n${textoDocumentacion}`;
+    const historialPlano = historial.map(m => `${m.rol === 'usuario' ? 'Usuario' : 'IA'}: ${m.contenido}`).join('\n');
+    const promptCompleto = `${instrucciones}\n\nHistorial:\n${historialPlano}\n\nUsuario: ${textoUsuario}\nIA:`;
+
+    let ultimoError = null;
+    for (const key of gameData.apiKeys) {
+        for (const modelo of gameData.modelFallbackOrder) {
+            try {
+                const resp = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${modelo}:generateContent?key=${key}`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ contents: [{ parts: [{ text: promptCompleto }] }] })
+                });
+                if (!resp.ok) {
+                    ultimoError = new Error(`Error de la API con ${modelo}: ${resp.status} ${resp.statusText}`);
+                    continue;
+                }
+                const data = await resp.json();
+                const texto = data?.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+                if (texto) return texto;
+                ultimoError = new Error('Respuesta vacía de la IA');
+            } catch (e) {
+                ultimoError = e;
+            }
+        }
+    }
+    console.warn(ultimoError);
+    return 'Ocurrió un error al consultar la IA.';
+}
+
+// Eventos de UI
+
+document.getElementById('enviar-mensaje').addEventListener('click', enviarMensaje);
+document.getElementById('mensaje-usuario').addEventListener('keydown', e => {
+    if (e.key === 'Enter') enviarMensaje();
+});
+
+cargarDocumentacion();

--- a/js/config.js
+++ b/js/config.js
@@ -40,6 +40,19 @@ export const gameData = {
         "gemini-2.5-flash",
         "gemini-2.5-flash-lite"
     ],
+    // Archivos de documentación que la IA puede consultar
+    archivosDocumentacion: [
+        'mobs.md',
+        'objects.md',
+        'rooms.md',
+        'resets.md',
+        'shops.md',
+        'specials.md',
+        'sets.md',
+        'spec.md',
+        'mobprog reducidoV1.23.md',
+        'petrarea v2.0.md'
+    ],
     // Lista de razas disponibles para los mobs en el juego.
     // Utilizada para poblar los selectores de raza en la interfaz de usuario.
     races: [

--- a/resumen.md
+++ b/resumen.md
@@ -1,3 +1,6 @@
+*   **Asistente IA contextual**:
+    *   Botón flotante siempre visible que abre un chat en una ventana separada.
+    *   El asistente solo responde dudas sobre la aplicación usando la documentación de `documentos/`.
 *   **Controles de Sección Fijos**:
     *   Se añadieron botones para contraer y expandir todas las tarjetas de cada sección.
     *   Los encabezados de sección permanecen fijos al desplazarse, manteniendo visibles los botones de añadir y los nuevos controles.

--- a/script.js
+++ b/script.js
@@ -11,6 +11,8 @@ import { gameData } from './js/config.js';
 import { parseAreFile } from './js/parser.js';
 
 
+let ventanaChat = null; // Referencia a la ventana del chat IA
+
 function populateMaterialsDatalist() {
     const datalist = document.getElementById('materials-list');
     if (datalist) {
@@ -92,6 +94,18 @@ document.addEventListener('DOMContentLoaded', () => {
             reader.readAsText(file);
         }
     });
+
+    // Botón flotante para abrir la ventana de chat con IA
+    const botonChat = document.getElementById('btn-chat-ia');
+    if (botonChat) {
+        botonChat.addEventListener('click', () => {
+            if (!ventanaChat || ventanaChat.closed) {
+                ventanaChat = window.open('chat.html', 'ChatIA', 'width=400,height=600');
+            } else {
+                ventanaChat.focus();
+            }
+        });
+    }
 });
 
 function isValidVnumRange() {

--- a/style.css
+++ b/style.css
@@ -449,3 +449,22 @@ select:focus {
     padding: 0;
     list-style: disc;
 }
+
+/* Botón flotante para el chat de IA */
+.boton-chat-ia {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    background-color: var(--header-color);
+    color: var(--bg-color);
+    border: 1px solid var(--text-color);
+    cursor: pointer;
+    font-weight: bold;
+}
+
+.boton-chat-ia:hover {
+    background-color: var(--text-color);
+}


### PR DESCRIPTION
## Resumen
- Añadido botón flotante que abre un chat de ayuda en una ventana separada.
- Configuración y módulo de chat cargan documentación de `documentos/` y limitan las respuestas a la aplicación.
- Actualizadas instrucciones y resumen para reflejar la nueva funcionalidad.

## Pruebas
- `node --check script.js`
- `node --check js/chat.js`
- `node --check js/config.js`


------
https://chatgpt.com/codex/tasks/task_e_68bcb7249048832d98cc0baf80265269