### PR TITLE
Agregar personalización de tema con modos predefinidos

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,11 @@
                         ADVERTENCIAS
                     </button>
                 </li>
+                <li>
+                    <button class="nav-btn" data-section="tema">
+                        TEMA
+                    </button>
+                </li>
             </ul>
         </nav>
         <main>
@@ -380,6 +385,23 @@
                 <ul id="advertencias-rooms"></ul>
                 <h3>RESETS</h3>
                 <ul id="advertencias-resets"></ul>
+            </section>
+            <section class="content-section" id="tema">
+                <h2 id="tema-header">
+                    TEMA
+                </h2>
+                <div class="form-group">
+                    <label for="modo-tema">
+                        Modo predefinido:
+                    </label>
+                    <select id="modo-tema">
+                        <option value="personalizado">Personalizado</option>
+                        <option value="oscuro">Oscuro clásico</option>
+                        <option value="claro">Claro</option>
+                        <option value="azul">Azul</option>
+                    </select>
+                </div>
+                <div id="colores-personalizados"></div>
             </section>
         </main>
     </div>

--- a/instrucciones.md
+++ b/instrucciones.md
@@ -345,6 +345,7 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Se reemplazó la sección **RESUMEN** por listas desplegables que enumeran los elementos de cada apartado, eliminando las estadísticas.
 - Se añadió un botón flotante que abre una ventana de chat con la IA. Esta IA responde únicamente dudas sobre la aplicación utilizando la documentación del directorio `documentos/`.
 - Se mejoró la ventana de chat mostrando las respuestas en varias líneas y un aviso de "Procesando..." mientras la IA genera la respuesta.
+- Se añadió la sección **TEMA** para personalizar los colores de la interfaz, ofreciendo modos predefinidos y ajustes individuales.
 
 
 

--- a/js/tema.js
+++ b/js/tema.js
@@ -1,0 +1,113 @@
+const temasPredefinidos = {
+    oscuro: {
+        '--bg-color': '#000000',
+        '--primary-color': '#0a0a0a',
+        '--secondary-color': '#1a1a1a',
+        '--text-color': '#00ff00',
+        '--header-color': '#33ff33',
+        '--input-bg': '#111111',
+        '--border-color': '#008800'
+    },
+    claro: {
+        '--bg-color': '#ffffff',
+        '--primary-color': '#f0f0f0',
+        '--secondary-color': '#e0e0e0',
+        '--text-color': '#000000',
+        '--header-color': '#006600',
+        '--input-bg': '#ffffff',
+        '--border-color': '#006600'
+    },
+    azul: {
+        '--bg-color': '#e6f0ff',
+        '--primary-color': '#cce0ff',
+        '--secondary-color': '#99c2ff',
+        '--text-color': '#003366',
+        '--header-color': '#0055aa',
+        '--input-bg': '#ffffff',
+        '--border-color': '#0055aa'
+    }
+};
+
+const variablesTema = [
+    { var: '--bg-color', etiqueta: 'Fondo' },
+    { var: '--primary-color', etiqueta: 'Primario' },
+    { var: '--secondary-color', etiqueta: 'Secundario' },
+    { var: '--text-color', etiqueta: 'Texto' },
+    { var: '--header-color', etiqueta: 'Encabezado' },
+    { var: '--input-bg', etiqueta: 'Fondo de entrada' },
+    { var: '--border-color', etiqueta: 'Borde' }
+];
+
+function aplicarTema(colores) {
+    const raiz = document.documentElement;
+    Object.entries(colores).forEach(([propiedad, valor]) => {
+        raiz.style.setProperty(propiedad, valor);
+        const input = document.querySelector(`input[data-var="${propiedad}"]`);
+        if (input) input.value = valor;
+    });
+}
+
+function guardarTema(colores) {
+    localStorage.setItem('temaPersonalizado', JSON.stringify(colores));
+}
+
+function obtenerColoresActuales() {
+    const estilos = getComputedStyle(document.documentElement);
+    const resultado = {};
+    variablesTema.forEach(cfg => {
+        resultado[cfg.var] = estilos.getPropertyValue(cfg.var).trim();
+    });
+    return resultado;
+}
+
+function cargarTema() {
+    const datos = localStorage.getItem('temaPersonalizado');
+    if (datos) {
+        try {
+            const colores = JSON.parse(datos);
+            aplicarTema(colores);
+        } catch (e) {}
+    }
+    const selectorModo = document.getElementById('modo-tema');
+    const nombre = Object.keys(temasPredefinidos).find(n => compararTemas(temasPredefinidos[n], obtenerColoresActuales()));
+    selectorModo.value = nombre || 'personalizado';
+}
+
+function compararTemas(a, b) {
+    return Object.keys(a).every(k => a[k].toLowerCase() === b[k]?.toLowerCase());
+}
+
+export function setupTemaSection() {
+    const contenedor = document.getElementById('colores-personalizados');
+    variablesTema.forEach(cfg => {
+        const div = document.createElement('div');
+        div.className = 'form-group';
+        const label = document.createElement('label');
+        label.textContent = cfg.etiqueta;
+        const input = document.createElement('input');
+        input.type = 'color';
+        input.dataset.var = cfg.var;
+        input.addEventListener('input', () => {
+            const colores = obtenerColoresActuales();
+            colores[cfg.var] = input.value;
+            aplicarTema(colores);
+            guardarTema(colores);
+            document.getElementById('modo-tema').value = 'personalizado';
+        });
+        div.appendChild(label);
+        div.appendChild(input);
+        contenedor.appendChild(div);
+    });
+
+    const selectorModo = document.getElementById('modo-tema');
+    selectorModo.addEventListener('change', () => {
+        const colores = temasPredefinidos[selectorModo.value];
+        if (colores) {
+            aplicarTema(colores);
+            guardarTema(colores);
+        }
+    });
+
+    aplicarTema(obtenerColoresActuales());
+    cargarTema();
+}

--- a/resumen.md
+++ b/resumen.md
@@ -2,6 +2,10 @@
     *   Botón flotante siempre visible que abre un chat en una ventana separada.
     *   El asistente solo responde dudas sobre la aplicación usando la documentación de `documentos/`.
     *   Las respuestas del chat se muestran con saltos de línea y un aviso de "Procesando..." indica que la IA está pensando.
+*   **Personalización de Tema**:
+    *   Se agregó una sección "Tema" en la navegación.
+    *   Ofrece modos de color predefinidos (oscuro, claro y azul).
+    *   Permite ajustar individualmente los colores base de la interfaz y guarda la preferencia en el navegador.
 *   **Controles de Sección Fijos**:
     *   Se añadieron botones para contraer y expandir todas las tarjetas de cada sección.
     *   Los encabezados de sección permanecen fijos al desplazarse, manteniendo visibles los botones de añadir y los nuevos controles.

--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ import { setupSpecialsSection, generateSpecialsSection } from './js/specials.js'
 import { setupProgsSection, generateProgsSection } from './js/progs.js';
 import { gameData } from './js/config.js';
 import { parseAreFile } from './js/parser.js';
+import { setupTemaSection } from './js/tema.js';
 
 
 let ventanaChat = null; // Referencia a la ventana del chat IA
@@ -52,6 +53,7 @@ document.addEventListener('DOMContentLoaded', () => {
     setupProgsSection('roomprogs', isValidVnumRange, '.prog-vnum', '.prog-vnum-display', null, null);
 
     populateMaterialsDatalist(); // Call the new function here
+    setupTemaSection();
 
     actualizarResumenYContadores();
 

--- a/style.css
+++ b/style.css
@@ -142,6 +142,7 @@ form {
 
 .form-group input[type="text"],
 .form-group input[type="number"],
+.form-group input[type="color"],
 textarea,
 select {
     background-color: var(--input-bg);


### PR DESCRIPTION
## Resumen
- Se creó una nueva sección "Tema" con botones de navegación.
- Se implementó `setupTemaSection` para cambiar colores y guardar la preferencia.
- Se añadieron tres modos predefinidos: oscuro, claro y azul, además de ajustes individuales.

## Pruebas
- `npm test` (falla: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68be8d0da248832d95a3567318450c9d