### PR TITLE
Ampliar modos de tema y mostrar VNUMs en resumen

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,11 @@
                         ADVERTENCIAS
                     </button>
                 </li>
+                <li>
+                    <button class="nav-btn" data-section="tema">
+                        TEMA
+                    </button>
+                </li>
             </ul>
         </nav>
         <main>
@@ -380,6 +385,30 @@
                 <ul id="advertencias-rooms"></ul>
                 <h3>RESETS</h3>
                 <ul id="advertencias-resets"></ul>
+            </section>
+            <section class="content-section" id="tema">
+                <h2 id="tema-header">
+                    TEMA
+                </h2>
+                <div class="form-group">
+                    <label for="modo-tema">
+                        Modo predefinido:
+                    </label>
+                    <select id="modo-tema">
+                        <option value="personalizado">Personalizado</option>
+                        <option value="oscuro">Oscuro clásico</option>
+                        <option value="claro">Claro</option>
+                        <option value="azul">Azul</option>
+                        <option value="vampirico">Vampírico</option>
+                        <option value="druida">Druida del Bosque</option>
+                        <option value="taberna">Taberna de Ron</option>
+                        <option value="arcano">Arcano Místico</option>
+                        <option value="hielo">Fortaleza de Hielo</option>
+                        <option value="dragon">Guarida de Dragón</option>
+                        <option value="payaso">Circo del Payaso</option>
+                    </select>
+                </div>
+                <div id="colores-personalizados"></div>
             </section>
         </main>
     </div>

--- a/instrucciones.md
+++ b/instrucciones.md
@@ -345,6 +345,10 @@ Adjunta el archivo `aligator.are` como un ejemplo concreto de cómo debe lucir e
 - Se reemplazó la sección **RESUMEN** por listas desplegables que enumeran los elementos de cada apartado, eliminando las estadísticas.
 - Se añadió un botón flotante que abre una ventana de chat con la IA. Esta IA responde únicamente dudas sobre la aplicación utilizando la documentación del directorio `documentos/`.
 - Se mejoró la ventana de chat mostrando las respuestas en varias líneas y un aviso de "Procesando..." mientras la IA genera la respuesta.
+- Se añadió la sección **TEMA** para personalizar los colores de la interfaz, ofreciendo modos predefinidos y ajustes individuales.
+- El tema seleccionado se aplica también a la ventana del chat con la IA y se sincroniza al modificar los colores.
+- Se ampliaron los modos predefinidos a diez con nombres roleros como Vampírico, Druida del Bosque, Taberna de Ron, Arcano Místico, Fortaleza de Hielo, Guarida de Dragón y Circo del Payaso.
+- La sección **RESUMEN** muestra el nombre de cada elemento junto a su VNUM entre paréntesis.
 
 
 

--- a/js/chat.js
+++ b/js/chat.js
@@ -1,9 +1,13 @@
 import { gameData } from './config.js';
+import { cargarTema } from './tema.js';
 
 // Contenedor de la documentación cargada desde documentos/*.md
 let textoDocumentacion = '';
 // Historial simple de mensajes para contextualizar a la IA
 const historial = [];
+
+cargarTema();
+window.addEventListener('storage', cargarTema);
 
 async function cargarDocumentacion() {
     const textos = await Promise.all(

--- a/js/tema.js
+++ b/js/tema.js
@@ -1,0 +1,178 @@
+const temasPredefinidos = {
+    oscuro: {
+        '--bg-color': '#000000',
+        '--primary-color': '#0a0a0a',
+        '--secondary-color': '#1a1a1a',
+        '--text-color': '#00ff00',
+        '--header-color': '#33ff33',
+        '--input-bg': '#111111',
+        '--border-color': '#008800'
+    },
+    claro: {
+        '--bg-color': '#ffffff',
+        '--primary-color': '#f0f0f0',
+        '--secondary-color': '#e0e0e0',
+        '--text-color': '#000000',
+        '--header-color': '#006600',
+        '--input-bg': '#ffffff',
+        '--border-color': '#006600'
+    },
+    azul: {
+        '--bg-color': '#e6f0ff',
+        '--primary-color': '#cce0ff',
+        '--secondary-color': '#99c2ff',
+        '--text-color': '#003366',
+        '--header-color': '#0055aa',
+        '--input-bg': '#ffffff',
+        '--border-color': '#0055aa'
+    },
+    vampirico: {
+        '--bg-color': '#1a0000',
+        '--primary-color': '#330000',
+        '--secondary-color': '#660000',
+        '--text-color': '#ff3333',
+        '--header-color': '#ff6666',
+        '--input-bg': '#330000',
+        '--border-color': '#990000'
+    },
+    druida: {
+        '--bg-color': '#002b00',
+        '--primary-color': '#004400',
+        '--secondary-color': '#006600',
+        '--text-color': '#ccffcc',
+        '--header-color': '#33aa33',
+        '--input-bg': '#003300',
+        '--border-color': '#336633'
+    },
+    taberna: {
+        '--bg-color': '#2b1d0e',
+        '--primary-color': '#3e2a16',
+        '--secondary-color': '#5c3c1f',
+        '--text-color': '#f2e1c2',
+        '--header-color': '#d4a76a',
+        '--input-bg': '#3e2a16',
+        '--border-color': '#d4a76a'
+    },
+    arcano: {
+        '--bg-color': '#0e0e2b',
+        '--primary-color': '#1a1a3e',
+        '--secondary-color': '#242467',
+        '--text-color': '#d1c4e9',
+        '--header-color': '#7e57c2',
+        '--input-bg': '#1a1a3e',
+        '--border-color': '#7e57c2'
+    },
+    hielo: {
+        '--bg-color': '#e0f7ff',
+        '--primary-color': '#c2e9fb',
+        '--secondary-color': '#a6dcef',
+        '--text-color': '#004d66',
+        '--header-color': '#0099cc',
+        '--input-bg': '#ffffff',
+        '--border-color': '#0099cc'
+    },
+    dragon: {
+        '--bg-color': '#330000',
+        '--primary-color': '#661a00',
+        '--secondary-color': '#993300',
+        '--text-color': '#ffcc66',
+        '--header-color': '#ff6600',
+        '--input-bg': '#661a00',
+        '--border-color': '#cc3300'
+    },
+    payaso: {
+        '--bg-color': '#ffffe6',
+        '--primary-color': '#fff2cc',
+        '--secondary-color': '#ffe0e0',
+        '--text-color': '#000099',
+        '--header-color': '#ff00ff',
+        '--input-bg': '#ffffff',
+        '--border-color': '#ff66ff'
+    }
+};
+
+const variablesTema = [
+    { var: '--bg-color', etiqueta: 'Fondo' },
+    { var: '--primary-color', etiqueta: 'Primario' },
+    { var: '--secondary-color', etiqueta: 'Secundario' },
+    { var: '--text-color', etiqueta: 'Texto' },
+    { var: '--header-color', etiqueta: 'Encabezado' },
+    { var: '--input-bg', etiqueta: 'Fondo de entrada' },
+    { var: '--border-color', etiqueta: 'Borde' }
+];
+
+function aplicarTema(colores) {
+    const raiz = document.documentElement;
+    Object.entries(colores).forEach(([propiedad, valor]) => {
+        raiz.style.setProperty(propiedad, valor);
+        const input = document.querySelector(`input[data-var="${propiedad}"]`);
+        if (input) input.value = valor;
+    });
+}
+
+function guardarTema(colores) {
+    localStorage.setItem('temaPersonalizado', JSON.stringify(colores));
+}
+
+function obtenerColoresActuales() {
+    const estilos = getComputedStyle(document.documentElement);
+    const resultado = {};
+    variablesTema.forEach(cfg => {
+        resultado[cfg.var] = estilos.getPropertyValue(cfg.var).trim();
+    });
+    return resultado;
+}
+
+export function cargarTema() {
+    const datos = localStorage.getItem('temaPersonalizado');
+    if (datos) {
+        try {
+            const colores = JSON.parse(datos);
+            aplicarTema(colores);
+        } catch (e) {}
+    }
+    const selectorModo = document.getElementById('modo-tema');
+    if (selectorModo) {
+        const nombre = Object.keys(temasPredefinidos).find(n => compararTemas(temasPredefinidos[n], obtenerColoresActuales()));
+        selectorModo.value = nombre || 'personalizado';
+    }
+}
+
+function compararTemas(a, b) {
+    return Object.keys(a).every(k => a[k].toLowerCase() === b[k]?.toLowerCase());
+}
+
+export function setupTemaSection() {
+    const contenedor = document.getElementById('colores-personalizados');
+    variablesTema.forEach(cfg => {
+        const div = document.createElement('div');
+        div.className = 'form-group';
+        const label = document.createElement('label');
+        label.textContent = cfg.etiqueta;
+        const input = document.createElement('input');
+        input.type = 'color';
+        input.dataset.var = cfg.var;
+        input.addEventListener('input', () => {
+            const colores = obtenerColoresActuales();
+            colores[cfg.var] = input.value;
+            aplicarTema(colores);
+            guardarTema(colores);
+            document.getElementById('modo-tema').value = 'personalizado';
+        });
+        div.appendChild(label);
+        div.appendChild(input);
+        contenedor.appendChild(div);
+    });
+
+    const selectorModo = document.getElementById('modo-tema');
+    selectorModo.addEventListener('change', () => {
+        const colores = temasPredefinidos[selectorModo.value];
+        if (colores) {
+            aplicarTema(colores);
+            guardarTema(colores);
+        }
+    });
+
+    aplicarTema(obtenerColoresActuales());
+    cargarTema();
+}

--- a/resumen.md
+++ b/resumen.md
@@ -2,6 +2,11 @@
     *   Botón flotante siempre visible que abre un chat en una ventana separada.
     *   El asistente solo responde dudas sobre la aplicación usando la documentación de `documentos/`.
     *   Las respuestas del chat se muestran con saltos de línea y un aviso de "Procesando..." indica que la IA está pensando.
+*   **Personalización de Tema**:
+    *   Se agregó una sección "Tema" en la navegación.
+    *   Ofrece diez modos de color roleros (oscuro, claro, azul, vampírico, druida, taberna, arcano, hielo, dragón y payaso).
+    *   Permite ajustar individualmente los colores base de la interfaz y guarda la preferencia en el navegador.
+    *   El cambio de tema se aplica también a la ventana del chat con la IA.
 *   **Controles de Sección Fijos**:
     *   Se añadieron botones para contraer y expandir todas las tarjetas de cada sección.
     *   Los encabezados de sección permanecen fijos al desplazarse, manteniendo visibles los botones de añadir y los nuevos controles.
@@ -124,4 +129,4 @@
 
 *   **Contadores y Resumen Visual**:
     *   Los encabezados de cada sección muestran la cantidad de elementos correspondientes y el archivo `.are` generado incluye estos totales.
-    *   La sección **RESUMEN** ofrece listas desplegables con los elementos de cada apartado para consultarlos de forma rápida.
+    *   La sección **RESUMEN** ofrece listas desplegables con los elementos de cada apartado para consultarlos de forma rápida e incluye el VNUM de cada elemento entre paréntesis.

--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ import { setupSpecialsSection, generateSpecialsSection } from './js/specials.js'
 import { setupProgsSection, generateProgsSection } from './js/progs.js';
 import { gameData } from './js/config.js';
 import { parseAreFile } from './js/parser.js';
+import { setupTemaSection } from './js/tema.js';
 
 
 let ventanaChat = null; // Referencia a la ventana del chat IA
@@ -52,6 +53,7 @@ document.addEventListener('DOMContentLoaded', () => {
     setupProgsSection('roomprogs', isValidVnumRange, '.prog-vnum', '.prog-vnum-display', null, null);
 
     populateMaterialsDatalist(); // Call the new function here
+    setupTemaSection();
 
     actualizarResumenYContadores();
 
@@ -146,7 +148,8 @@ const resumenConfig = [
         contenedor: '#mobiles-container',
         selectorTarjeta: '.mob-card',
         idEncabezado: 'mobiles-header',
-        selectorNombre: '.mob-name-display'
+        selectorNombre: '.mob-name-display',
+        selectorVnum: '.mob-vnum-display'
     },
     {
         id: 'objects',
@@ -154,7 +157,8 @@ const resumenConfig = [
         contenedor: '#objects-container',
         selectorTarjeta: '.object-card',
         idEncabezado: 'objects-header',
-        selectorNombre: '.obj-name-display'
+        selectorNombre: '.obj-name-display',
+        selectorVnum: '.obj-vnum-display'
     },
     {
         id: 'rooms',
@@ -162,7 +166,8 @@ const resumenConfig = [
         contenedor: '#rooms-container',
         selectorTarjeta: '.room-card',
         idEncabezado: 'rooms-header',
-        selectorNombre: '.room-name-display'
+        selectorNombre: '.room-name-display',
+        selectorVnum: '.room-vnum-display'
     },
     {
         id: 'resets',
@@ -174,6 +179,12 @@ const resumenConfig = [
             const tipo = fila.dataset.type || '';
             const comentario = fila.querySelector('.reset-comment')?.value.trim();
             return comentario ? `${tipo} - ${comentario}` : tipo;
+        },
+        obtenerVnum: fila => {
+            return Array.from(fila.querySelectorAll('[class*="vnum"]'))
+                .map(el => el.value || el.textContent.trim())
+                .filter(Boolean)
+                .join('/');
         }
     },
     {
@@ -182,7 +193,8 @@ const resumenConfig = [
         contenedor: '#sets-container',
         selectorTarjeta: '.set-card',
         idEncabezado: 'set-header',
-        selectorNombre: '.set-name-display'
+        selectorNombre: '.set-name-display',
+        selectorVnum: '.set-id-display'
     },
     {
         id: 'shops',
@@ -192,9 +204,9 @@ const resumenConfig = [
         idEncabezado: 'shops-header',
         obtenerNombre: tarjeta => {
             const comentario = tarjeta.querySelector('.shop-comment')?.value.trim();
-            const vnum = tarjeta.querySelector('.shop-vnum')?.value;
-            return comentario || `Tienda ${vnum || ''}`.trim();
-        }
+            return comentario || 'Tienda';
+        },
+        selectorVnum: '.shop-vnum-display'
     },
     {
         id: 'specials',
@@ -206,7 +218,8 @@ const resumenConfig = [
             const nombre = tarjeta.querySelector('.special-name-display')?.textContent.trim();
             const comentario = tarjeta.querySelector('.special-comment-display')?.textContent.trim();
             return comentario ? `${nombre} - ${comentario}` : nombre;
-        }
+        },
+        selectorVnum: '.special-vnum-display'
     },
     {
         id: 'mobprogs',
@@ -215,10 +228,10 @@ const resumenConfig = [
         selectorTarjeta: '.prog-card',
         idEncabezado: 'mobprogs-header',
         obtenerNombre: tarjeta => {
-            const vnum = tarjeta.querySelector('.prog-vnum-display')?.textContent.trim();
             const propietario = tarjeta.querySelector('.prog-owner-display')?.selectedOptions[0]?.textContent.trim();
-            return `${vnum || ''}${propietario ? ' - ' + propietario : ''}`.trim();
-        }
+            return propietario || 'Prog';
+        },
+        selectorVnum: '.prog-vnum-display'
     },
     {
         id: 'objprogs',
@@ -227,10 +240,10 @@ const resumenConfig = [
         selectorTarjeta: '.prog-card',
         idEncabezado: 'objprogs-header',
         obtenerNombre: tarjeta => {
-            const vnum = tarjeta.querySelector('.prog-vnum-display')?.textContent.trim();
             const propietario = tarjeta.querySelector('.prog-owner-display')?.selectedOptions[0]?.textContent.trim();
-            return `${vnum || ''}${propietario ? ' - ' + propietario : ''}`.trim();
-        }
+            return propietario || 'Prog';
+        },
+        selectorVnum: '.prog-vnum-display'
     },
     {
         id: 'roomprogs',
@@ -239,10 +252,10 @@ const resumenConfig = [
         selectorTarjeta: '.prog-card',
         idEncabezado: 'roomprogs-header',
         obtenerNombre: tarjeta => {
-            const vnum = tarjeta.querySelector('.prog-vnum-display')?.textContent.trim();
             const propietario = tarjeta.querySelector('.prog-owner-display')?.selectedOptions[0]?.textContent.trim();
-            return `${vnum || ''}${propietario ? ' - ' + propietario : ''}`.trim();
-        }
+            return propietario || 'Prog';
+        },
+        selectorVnum: '.prog-vnum-display'
     }
 ];
 
@@ -278,9 +291,16 @@ function actualizarResumenYContadores() {
                 } else if (cfg.obtenerNombre) {
                     nombre = cfg.obtenerNombre(tarjeta);
                 }
+                let vnum = '';
+                if (cfg.selectorVnum) {
+                    const vnumElem = tarjeta.querySelector(cfg.selectorVnum);
+                    if (vnumElem) vnum = vnumElem.textContent.trim() || vnumElem.value || '';
+                } else if (cfg.obtenerVnum) {
+                    vnum = cfg.obtenerVnum(tarjeta);
+                }
                 if (!nombre) nombre = '(sin nombre)';
                 const li = document.createElement('li');
-                li.textContent = nombre;
+                li.textContent = vnum ? `${nombre} (${vnum})` : nombre;
                 lista.appendChild(li);
             });
             if (!lista.childElementCount) {

--- a/style.css
+++ b/style.css
@@ -142,6 +142,7 @@ form {
 
 .form-group input[type="text"],
 .form-group input[type="number"],
+.form-group input[type="color"],
 textarea,
 select {
     background-color: var(--input-bg);


### PR DESCRIPTION
## Resumen
- Se añadieron siete modos de color roleros y el tema elegido también se aplica al chat con la IA.
- La sección RESUMEN ahora muestra cada elemento acompañado de su VNUM entre paréntesis.
- Se actualizaron instrucciones.md y resumen.md para reflejar estas mejoras.

## Pruebas
- `npm test` (falla: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68be8d0da248832d95a3567318450c9d